### PR TITLE
feat: add total_points to leaderboard stats response

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3493,6 +3493,7 @@ components:
         - appointments_completed
         - sales_meetings
         - sales_successful
+        - total_points
       properties:
         user_id:
           type: string
@@ -3531,6 +3532,10 @@ components:
           type: integer
           description: Number of successful sales closed in the period.
           example: 2
+        total_points:
+          type: integer
+          description: Pre-computed total points for this agent in the period, calculated server-side using the tenant's current point config.
+          example: 26
 
     LeaderboardStatsGroupObject:
       type: object
@@ -3543,6 +3548,7 @@ components:
         - appointments_completed
         - sales_meetings
         - sales_successful
+        - total_points
       properties:
         group_id:
           type: string
@@ -3576,6 +3582,10 @@ components:
           type: integer
           description: Aggregated number of successful sales closed by all group members in the period.
           example: 8
+        total_points:
+          type: integer
+          description: Aggregated total points for all members of this group in the period, calculated server-side using the tenant's current point config.
+          example: 52
 
     AgentPointsObject:
       type: object

--- a/src/types/leaderboard.types.ts
+++ b/src/types/leaderboard.types.ts
@@ -23,6 +23,7 @@ export type ILeaderboardStatsIndividual = {
   appointments_completed: number;
   sales_meetings: number;
   sales_successful: number;
+  total_points: number;
 };
 
 export type ILeaderboardStatsGroup = {
@@ -34,6 +35,7 @@ export type ILeaderboardStatsGroup = {
   appointments_completed: number;
   sales_meetings: number;
   sales_successful: number;
+  total_points: number;
 };
 
 export type ILeaderboardStats = {

--- a/supabase/migrations/20260331173034_add_total_points_to_leaderboard_stats.sql
+++ b/supabase/migrations/20260331173034_add_total_points_to_leaderboard_stats.sql
@@ -1,0 +1,98 @@
+-- Adds pre-computed total_points to both individual and group entries.
+-- Uses correlated subqueries to avoid row multiplication from the existing
+-- LEFT JOIN prospects aggregation.
+CREATE OR REPLACE FUNCTION get_leaderboard_stats(
+  p_tenant_id UUID,
+  p_period_start TIMESTAMPTZ
+)
+RETURNS JSON AS $$
+DECLARE
+  v_individual JSON;
+  v_groups JSON;
+BEGIN
+  -- Individual stats per agent/group_leader
+  SELECT json_agg(individual_stats)
+  INTO v_individual
+  FROM (
+    SELECT
+      u.id AS user_id,
+      u.name,
+      u.agent_code,
+      u.group_id,
+      g.name AS group_name,
+      COUNT(p.id) FILTER (WHERE p.created_at >= p_period_start) AS prospects_added,
+      COUNT(p.id) FILTER (
+        WHERE p.appointment_status = 'done'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS appointments_completed,
+      COUNT(p.id) FILTER (
+        WHERE p.current_stage = 'sales'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_meetings,
+      COUNT(p.id) FILTER (
+        WHERE p.sales_outcome = 'successful'
+        AND COALESCE(p.sales_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_successful,
+      COALESCE((
+        SELECT SUM(pt.points)
+        FROM public.point_transactions pt
+        WHERE pt.user_id   = u.id
+          AND pt.tenant_id = p_tenant_id
+          AND pt.created_at >= p_period_start
+      ), 0) AS total_points
+    FROM public.users u
+    LEFT JOIN public.groups g ON g.id = u.group_id
+    LEFT JOIN public.prospects p ON p.agent_id = u.id AND p.tenant_id = p_tenant_id
+    WHERE u.tenant_id = p_tenant_id
+      AND u.role IN ('agent', 'group_leader')
+    GROUP BY u.id, u.name, u.agent_code, u.group_id, g.name
+  ) individual_stats;
+
+  -- Group aggregated stats
+  SELECT json_agg(group_stats)
+  INTO v_groups
+  FROM (
+    SELECT
+      g.id AS group_id,
+      g.name AS group_name,
+      leader.name AS leader_name,
+      COUNT(DISTINCT u.id) AS member_count,
+      COUNT(p.id) FILTER (WHERE p.created_at >= p_period_start) AS prospects_added,
+      COUNT(p.id) FILTER (
+        WHERE p.appointment_status = 'done'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS appointments_completed,
+      COUNT(p.id) FILTER (
+        WHERE p.current_stage = 'sales'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_meetings,
+      COUNT(p.id) FILTER (
+        WHERE p.sales_outcome = 'successful'
+        AND COALESCE(p.sales_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_successful,
+      COALESCE((
+        SELECT SUM(pt.points)
+        FROM public.point_transactions pt
+        WHERE pt.tenant_id = p_tenant_id
+          AND pt.created_at >= p_period_start
+          AND pt.user_id IN (
+            SELECT u2.id FROM public.users u2
+            WHERE u2.group_id   = g.id
+              AND u2.tenant_id  = p_tenant_id
+              AND u2.role IN ('agent', 'group_leader')
+          )
+      ), 0) AS total_points
+    FROM public.groups g
+    LEFT JOIN public.users leader ON leader.id = g.leader_id AND leader.tenant_id = p_tenant_id
+    JOIN public.users u ON u.group_id = g.id AND u.role IN ('agent', 'group_leader') AND u.tenant_id = p_tenant_id
+    LEFT JOIN public.prospects p ON p.agent_id = u.id AND p.tenant_id = p_tenant_id
+    WHERE g.tenant_id = p_tenant_id
+    GROUP BY g.id, g.name, leader.name
+  ) group_stats;
+
+  RETURN json_build_object(
+    'individual', COALESCE(v_individual, '[]'::json),
+    'groups', COALESCE(v_groups, '[]'::json)
+  );
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER;

--- a/tests/integration/leaderboard.test.ts
+++ b/tests/integration/leaderboard.test.ts
@@ -250,11 +250,13 @@ describe('GET /api/leaderboard/stats — happy path (admin)', () => {
       expect(entry).toHaveProperty('appointments_completed');
       expect(entry).toHaveProperty('sales_meetings');
       expect(entry).toHaveProperty('sales_successful');
+      expect(entry).toHaveProperty('total_points');
 
       expect(typeof entry['prospects_added']).toBe('number');
       expect(typeof entry['appointments_completed']).toBe('number');
       expect(typeof entry['sales_meetings']).toBe('number');
       expect(typeof entry['sales_successful']).toBe('number');
+      expect(typeof entry['total_points']).toBe('number');
     }
   });
 
@@ -283,12 +285,14 @@ describe('GET /api/leaderboard/stats — happy path (admin)', () => {
       expect(entry).toHaveProperty('appointments_completed');
       expect(entry).toHaveProperty('sales_meetings');
       expect(entry).toHaveProperty('sales_successful');
+      expect(entry).toHaveProperty('total_points');
 
       expect(typeof entry['member_count']).toBe('number');
       expect(typeof entry['prospects_added']).toBe('number');
       expect(typeof entry['appointments_completed']).toBe('number');
       expect(typeof entry['sales_meetings']).toBe('number');
       expect(typeof entry['sales_successful']).toBe('number');
+      expect(typeof entry['total_points']).toBe('number');
     }
   });
 });


### PR DESCRIPTION
## Summary

- Adds a pre-computed `total_points` field to both individual and group entries in the `GET /leaderboard/stats` response
- Uses correlated subqueries on `point_transactions` to compute points per-period without row multiplication from the existing prospects join
- Updates TypeScript types (`ILeaderboardStatsIndividual`, `ILeaderboardStatsGroup`) and OpenAPI schemas accordingly

## Rationale

Previously the frontend had to fetch `pointConfig` separately and multiply raw activity counts client-side. This moves point calculation server-side, consistent with how `GET /agent-points` already returns a pre-computed `total`.

## Test plan

- [ ] All existing leaderboard integration tests pass (`npm test -- --testPathPatterns=leaderboard`)
- [ ] `GET /api/leaderboard/stats?period=mtd` returns `total_points` as a number on both `individual` and `groups` entries
- [ ] `GET /api/leaderboard/stats?period=ytd` likewise returns `total_points`
- [ ] Agents with no point transactions return `total_points: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)