### PR TITLE
fix: appointment_set detection and idempotency in award-points

### DIFF
--- a/supabase/functions/award-points/index.ts
+++ b/supabase/functions/award-points/index.ts
@@ -59,7 +59,10 @@ function detectActivity(payload: WebhookPayload): Activity | null {
   if (payload.type === "UPDATE" && payload.old_record) {
     const { record, old_record } = payload;
 
-    if (!old_record.appointment_date && record.appointment_date) {
+    if (
+      old_record.appointment_status !== "scheduled" &&
+      record.appointment_status === "scheduled"
+    ) {
       return "appointment_set";
     }
 
@@ -130,7 +133,25 @@ Deno.serve(async (req) => {
     }
     const subjectId = payload.record.id;
 
-    // Step 5: Insert point transaction
+    // Step 5: Idempotency — skip if points already awarded for this subject + activity
+    const { data: existing, error: existingError } = await supabase
+      .from("point_transactions")
+      .select("id")
+      .eq("tenant_id", tenantId)
+      .eq("subject_id", subjectId)
+      .eq("activity", activity)
+      .maybeSingle();
+
+    if (existingError) {
+      console.error("[award-points] Error checking existing transaction:", existingError);
+      return ok;
+    }
+
+    if (existing) {
+      return ok;
+    }
+
+    // Step 6: Insert point transaction
     const { error: insertError } = await supabase
       .from("point_transactions")
       .insert({

--- a/supabase/migrations/20260331182431_add_indexes_for_award_points_queries.sql
+++ b/supabase/migrations/20260331182431_add_indexes_for_award_points_queries.sql
@@ -1,0 +1,7 @@
+-- Composite index for point_configs lookup in award-points edge function
+-- Query pattern: WHERE tenant_id = ? AND activity = ?
+CREATE INDEX idx_point_configs_tenant_id_activity ON point_configs(tenant_id, activity);
+
+-- Composite index for idempotency check in award-points edge function
+-- Query pattern: WHERE tenant_id = ? AND subject_id = ? AND activity = ?
+CREATE INDEX idx_point_transactions_tenant_subject_activity ON point_transactions(tenant_id, subject_id, activity);


### PR DESCRIPTION
## Summary
- Changes `appointment_set` activity detection to fire when `appointment_status` transitions to `'scheduled'` (previously triggered on `appointment_date` null→set)
- Adds an idempotency check before inserting into `point_transactions` — queries by `(tenant_id, subject_id, activity)` and skips if a row already exists, preventing duplicate point awards from repeated status toggles
- Adds composite indexes to back both query patterns in the edge function

## Test plan
- [x] Update a prospect's `appointment_status` to `'scheduled'` for the first time → `appointment_set` points awarded
- [x] Change `appointment_status` away from `'scheduled'` then back → no duplicate points awarded
- [x] Update a prospect's `appointment_status` to `'not_done'` first, then `'scheduled'` → points awarded correctly on first `'scheduled'` transition
- [x] Insert a new prospect → `prospect_created` points awarded as before (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)