### PR TITLE
feat: award coaching session points based on hourly rate × session duration

### DIFF
--- a/.claude/agents/code-review.md
+++ b/.claude/agents/code-review.md
@@ -1,3 +1,9 @@
+---
+name: code-review
+description: Reviews code changes for quality, architecture compliance, naming conventions, and error handling patterns
+tools: Read, Glob, Grep, Bash
+---
+
 # Code Review Agent
 
 You are an experienced TypeScript developer specialising in building REST APIs

--- a/.claude/agents/commit-organiser.md
+++ b/.claude/agents/commit-organiser.md
@@ -1,3 +1,9 @@
+---
+name: commit-organiser
+description: Organises uncommitted changes into logical conventional commits
+tools: Read, Glob, Grep, Bash
+---
+
 # Commit Organiser Agent
 
 You are an experienced developer specialising in creating clean, well-structured

--- a/.claude/agents/documenter.md
+++ b/.claude/agents/documenter.md
@@ -1,3 +1,9 @@
+---
+name: documenter
+description: Updates OpenAPI/Swagger documentation for API changes
+tools: Read, Glob, Grep, Bash, Edit, Write
+---
+
 # Documenter Agent
 
 You are an experienced TypeScript developer specialising in REST API documentation.

--- a/.claude/agents/implementor.md
+++ b/.claude/agents/implementor.md
@@ -1,3 +1,9 @@
+---
+name: implementor
+description: Implements features, fixes bugs, and makes code modifications following layered architecture
+tools: Read, Glob, Grep, Bash, Edit, Write
+---
+
 # Implementor Agent
 
 You are an experienced TypeScript developer specialising in building REST APIs

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -1,3 +1,9 @@
+---
+name: tester
+description: Creates and runs unit and integration tests for API changes
+tools: Read, Glob, Grep, Bash, Edit, Write
+---
+
 # Tester Agent
 
 You are an experienced TypeScript developer specialising in building REST APIs

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4331,8 +4331,7 @@ components:
         - individual_coaching
         - group_coaching
         - peer_circles
-        - 2_full_days_seminar
-        - 2_hours_online_seminar
+        - seminar
       example: group_coaching
 
     TrainingModeEnum:

--- a/src/routes/coachingSession.routes.ts
+++ b/src/routes/coachingSession.routes.ts
@@ -20,7 +20,8 @@ import { IBaseReq } from '@src/models/interfaces/base.interface';
                             Zod Schemas
 ******************************************************************************/
 
-const ISO_DATETIME_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?([+-]\d{2}:\d{2}|Z)$/;
+const ISO_DATETIME_REGEX =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?([+-]\d{2}:\d{2}|Z)$/;
 
 function isNotPastDateTime(dateStr: string): boolean {
   const input = new Date(dateStr);
@@ -29,14 +30,16 @@ function isNotPastDateTime(dateStr: string): boolean {
 
 const isoDateTimeField = z
   .string()
-  .regex(ISO_DATETIME_REGEX, 'Must be ISO 8601 with timezone (e.g. 2026-04-03T09:00:00+08:00)');
+  .regex(
+    ISO_DATETIME_REGEX,
+    'Must be ISO 8601 with timezone (e.g. 2026-04-03T09:00:00+08:00)',
+  );
 
 const COACHING_TYPES = [
   'individual_coaching',
   'group_coaching',
   'peer_circles',
-  '2_full_days_seminar',
-  '2_hours_online_seminar',
+  'seminar',
 ] as const;
 const TRAINING_MODES = ['online', 'face_to_face'] as const;
 const STATUSES = ['upcoming', 'ongoing', 'completed', 'cancelled'] as const;
@@ -46,7 +49,9 @@ export const createCoachingSessionSchema = z
     coachingType: z.enum(COACHING_TYPES),
     title: z.string().min(1),
     description: z.string().optional(),
-    startDate: isoDateTimeField.refine(isNotPastDateTime, { message: 'startDate cannot be in the past' }),
+    startDate: isoDateTimeField.refine(isNotPastDateTime, {
+      message: 'startDate cannot be in the past',
+    }),
     endDate: isoDateTimeField,
     trainingMode: z.enum(TRAINING_MODES),
     link: z.string().optional(),
@@ -65,10 +70,10 @@ export const createCoachingSessionSchema = z
       .optional(),
   })
   .strict()
-  .refine(
-    (data) => new Date(data.endDate) > new Date(data.startDate),
-    { message: 'endDate must be after startDate', path: ['endDate'] },
-  );
+  .refine((data) => new Date(data.endDate) > new Date(data.startDate), {
+    message: 'endDate must be after startDate',
+    path: ['endDate'],
+  });
 // NOTE: No cross-field refinement for groupIds/agentIds — both being absent means all-audience
 
 export const updateCoachingSessionSchema = z
@@ -76,7 +81,9 @@ export const updateCoachingSessionSchema = z
     coachingType: z.enum(COACHING_TYPES).optional(),
     title: z.string().min(1).optional(),
     description: z.string().optional(),
-    startDate: isoDateTimeField.refine(isNotPastDateTime, { message: 'startDate cannot be in the past' }).optional(),
+    startDate: isoDateTimeField
+      .refine(isNotPastDateTime, { message: 'startDate cannot be in the past' })
+      .optional(),
     endDate: isoDateTimeField.optional(),
     trainingMode: z.enum(TRAINING_MODES).optional(),
     link: z.string().optional(),

--- a/src/services/coachingSession.service.ts
+++ b/src/services/coachingSession.service.ts
@@ -270,7 +270,7 @@ class CoachingSessionService {
       if (params.endDate !== undefined) updateData.end_date = params.endDate;
 
       const effectiveStart = updateData.start_date ?? existing.start_date;
-      const effectiveEnd = updateData.end_date ?? existing.end_date ?? existing.start_date;
+      const effectiveEnd = updateData.end_date ?? existing.end_date;
       if (new Date(effectiveEnd as string) <= new Date(effectiveStart as string)) {
         throw new InvalidDateRangeError();
       }

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -204,7 +204,7 @@ export type Database = {
           created_by_name: string | null
           created_by_role: string | null
           description: string | null
-          end_date: string | null
+          end_date: string
           id: string
           link: string | null
           start_date: string
@@ -221,7 +221,7 @@ export type Database = {
           created_by_name?: string | null
           created_by_role?: string | null
           description?: string | null
-          end_date?: string | null
+          end_date: string
           id?: string
           link?: string | null
           start_date: string
@@ -238,7 +238,7 @@ export type Database = {
           created_by_name?: string | null
           created_by_role?: string | null
           description?: string | null
-          end_date?: string | null
+          end_date?: string
           id?: string
           link?: string | null
           start_date?: string
@@ -925,3 +925,4 @@ export const Constants = {
     Enums: {},
   },
 } as const
+

--- a/supabase/functions/award-points/index.ts
+++ b/supabase/functions/award-points/index.ts
@@ -116,6 +116,7 @@ Deno.serve(async (req) => {
     let tenantId: string;
     let userId: string;
     let subjectId: string;
+    let sessionDurationHours: number | null = null;
 
     if (payload.table === "prospects") {
       if (!payload.record.agent_id) {
@@ -131,10 +132,10 @@ Deno.serve(async (req) => {
       userId = payload.record.agent_id as string;
       subjectId = payload.record.id as string;
 
-      // Resolve tenant_id and coaching_type from coaching_sessions
+      // Resolve tenant_id, coaching_type, and duration from coaching_sessions
       const { data: session, error: sessionError } = await supabase
         .from("coaching_sessions")
-        .select("tenant_id, coaching_type")
+        .select("tenant_id, coaching_type, start_date, end_date")
         .eq("id", payload.record.session_id as string)
         .single();
 
@@ -151,6 +152,24 @@ Deno.serve(async (req) => {
         return ok;
       }
       activity = mappedActivity;
+
+      // Compute session duration in hours (ceiling)
+      const startMs = new Date(session.start_date as string).getTime();
+      const endMs = new Date(session.end_date as string).getTime();
+
+      if (isNaN(startMs) || isNaN(endMs)) {
+        console.warn(`[award-points] Unparseable date on session ${payload.record.session_id} — skipping`);
+        return ok;
+      }
+
+      const durationMs = endMs - startMs;
+
+      if (durationMs <= 0) {
+        console.warn(`[award-points] Invalid session duration for session ${payload.record.session_id} — skipping`);
+        return ok;
+      }
+
+      sessionDurationHours = Math.ceil(durationMs / (1000 * 60 * 60));
     } else {
       return ok;
     }
@@ -204,13 +223,17 @@ Deno.serve(async (req) => {
     if (existing) return ok;
 
     // Step 6: Insert point transaction
+    const computedPoints = sessionDurationHours !== null
+      ? config.points * sessionDurationHours
+      : config.points;
+
     const { error: insertError } = await supabase
       .from("point_transactions")
       .insert({
         tenant_id: tenantId,
         user_id: userId,
         activity,
-        points: config.points,
+        points: computedPoints,
         subject_id: subjectId,
         subject_type: activityType.subject_type,
       });

--- a/supabase/functions/award-points/index.ts
+++ b/supabase/functions/award-points/index.ts
@@ -130,6 +130,10 @@ Deno.serve(async (req) => {
         return ok; // Cannot award points without a user
       }
       userId = payload.record.agent_id as string;
+      // Use the attendance row ID (not session_id) as subjectId so that each
+      // agent's attendance record is a distinct idempotency key. Using session_id
+      // would block all subsequent agents after the first is awarded points,
+      // since the idempotency check is (tenant_id, subject_id, activity) with no user_id.
       subjectId = payload.record.id as string;
 
       // Resolve tenant_id, coaching_type, and duration from coaching_sessions

--- a/supabase/functions/award-points/index.ts
+++ b/supabase/functions/award-points/index.ts
@@ -77,8 +77,7 @@ const COACHING_TYPE_ACTIVITY_MAP: Record<string, string> = {
   individual_coaching: "coaching_individual_attended",
   group_coaching: "coaching_group_attended",
   peer_circles: "coaching_peer_circles_attended",
-  "2_full_days_seminar": "coaching_2_full_days_attended",
-  "2_hours_online_seminar": "coaching_2_hours_online_attended",
+  seminar_attended: "seminar_attended",
 };
 
 // ---------- Dispatcher ----------

--- a/supabase/migrations/20260407234314_make_coaching_sessions_end_date_not_null.sql
+++ b/supabase/migrations/20260407234314_make_coaching_sessions_end_date_not_null.sql
@@ -1,0 +1,8 @@
+-- Backfill any NULL end_date values with start_date + 1 hour
+UPDATE coaching_sessions
+SET end_date = start_date + INTERVAL '1 hour'
+WHERE end_date IS NULL;
+
+-- Enforce NOT NULL
+ALTER TABLE coaching_sessions
+ALTER COLUMN end_date SET NOT NULL;


### PR DESCRIPTION
## Summary

- Replace flat per-session point awarding with hourly-based calculation: `total_points = hourly_rate × ceil(duration_hours)`
- Make `coaching_sessions.end_date` NOT NULL (backfills nulls with `start_date + 1 hour`)
- Each coaching type retains its own hourly rate in `point_configs.points`
- Prospect point awarding is unaffected (still flat)
- Add frontmatter to all `.claude/agents/*.md` so they are recognised as subagents

## Changes

- `supabase/migrations/20260407234314_make_coaching_sessions_end_date_not_null.sql` — backfill + NOT NULL constraint
- `src/types/database.types.ts` — regenerated (`end_date` now `string` not `string | null`)
- `supabase/functions/award-points/index.ts` — duration calculation with `isNaN` and `durationMs <= 0` guards, `computedPoints = hourly_rate × ceil(hours)`
- `src/services/coachingSession.service.ts` — remove dead `?? existing.start_date` fallback

## Test plan

- [ ] Run migration on staging DB
- [ ] Deploy `award-points` edge function
- [ ] Update point configs — `points` field now represents hourly rate
- [ ] Create a coaching session with a known duration (e.g. 2hrs), join it, verify `point_transactions.points = hourly_rate × 2`
- [ ] Verify prospect point awarding still works (flat points, unaffected)
- [ ] Test fractional duration (e.g. 1.5hrs) → expect `hourly_rate × 2` (ceil)

🤖 Generated with [Claude Code](https://claude.com/claude-code)