### PR TITLE
feat(users): add PATCH /api/users/me/password endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -597,6 +597,90 @@ paths:
   # USERS
   ##############################################################################
 
+  /users/me/password:
+    patch:
+      tags: [Users]
+      summary: Change the authenticated user's password
+      description: >
+        Updates the password for the currently authenticated user. The caller
+        must supply a valid Bearer token. The new password must be at least 6
+        characters and contain at least one uppercase letter, one digit, and
+        one special character.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [newPassword]
+              additionalProperties: false
+              properties:
+                newPassword:
+                  type: string
+                  minLength: 6
+                  description: >
+                    The replacement password. Must be at least 6 characters and
+                    contain at least one uppercase letter, one digit, and one
+                    special (non-alphanumeric) character.
+                  example: '$Test1'
+            example:
+              newPassword: '$Test1'
+      responses:
+        '200':
+          description: Password changed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, message]
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: Password changed successfully
+              example:
+                success: true
+                message: Password changed successfully
+        '400':
+          description: >
+            Bad request. Returned when the request body fails validation —
+            for example when `newPassword` is absent, too short, or does not
+            meet the complexity requirements.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                message: Validation failed
+                errors:
+                  - code: too_small
+                    minimum: 6
+                    type: string
+                    inclusive: true
+                    exact: false
+                    message: Password must be at least 6 characters
+                    path: [newPassword]
+        '401':
+          description: >
+            Unauthorized. Returned when the `Authorization` header is absent,
+            malformed, or contains an invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Unauthorized
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /users:
     get:
       tags: [Users]

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -76,6 +76,17 @@ export interface IDeleteUserRes extends IBaseRes {
   success: boolean;
 }
 
+export interface IChangePasswordReq extends IBaseReq {
+  body: {
+    newPassword: string;
+  };
+}
+
+export interface IChangePasswordRes extends IBaseRes {
+  success: boolean;
+  message: string;
+}
+
 /******************************************************************************
                             UserController
 ******************************************************************************/
@@ -190,6 +201,28 @@ class UserController {
       }
 
       return handleControllerError('UserController.delete', error, next);
+    }
+  }
+
+  async changePassword(
+    req: IChangePasswordReq,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const userId = req.user!.id;
+      const { newPassword } = req.body;
+
+      await userService.changePassword(userId, newPassword);
+
+      const responseBody: IChangePasswordRes = {
+        success: true,
+        message: 'Password changed successfully',
+      };
+
+      res.status(HttpStatusCodes.OK).json(responseBody);
+    } catch (error) {
+      return handleControllerError('UserController.changePassword', error, next);
     }
   }
 

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -377,6 +377,14 @@ class UserRepository {
       return handleRepositoryError('UserRepository.updateAgentCode', error);
     }
   }
+
+  async updateAuthUserPassword(userId: string, password: string): Promise<void> {
+    try {
+      await supabaseService.adminUpdateAuthUserPassword(userId, password);
+    } catch (error) {
+      return handleRepositoryError('UserRepository.updateAuthUserPassword', error);
+    }
+  }
 }
 
 /******************************************************************************

--- a/src/routes/user.routes.ts
+++ b/src/routes/user.routes.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { z } from 'zod';
 
 import userController, {
+  IChangePasswordReq,
   ICreateUserReq,
   IDeleteUserReq,
   IGetUserByIdReq,
@@ -29,6 +30,20 @@ export const updateUserSchema = z
   .refine((data) => Object.keys(data).length > 0, {
     message: 'At least one field must be provided',
   });
+
+export const changePasswordSchema = z
+  .object({
+    newPassword: z
+      .string()
+      .min(6, 'Password must be at least 6 characters')
+      .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
+      .regex(/[0-9]/, 'Password must contain at least one digit')
+      .regex(
+        /[^a-zA-Z0-9]/,
+        'Password must contain at least one special character',
+      ),
+  })
+  .strict();
 
 export const createUserSchema = z
   .object({
@@ -62,6 +77,14 @@ router.get(
   authenticate,
   (req, res, next) =>
     userController.getAll(req as unknown as IBaseReq, res, next),
+);
+
+router.patch(
+  '/me/password',
+  authenticate,
+  validate(changePasswordSchema),
+  (req, res, next) =>
+    userController.changePassword(req as unknown as IChangePasswordReq, res, next),
 );
 
 router.get(

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -191,6 +191,14 @@ class UserService {
     }
   }
 
+  async changePassword(userId: string, newPassword: string): Promise<void> {
+    try {
+      await userRepository.updateAuthUserPassword(userId, newPassword);
+    } catch (error) {
+      return handleServiceError('UserService.changePassword', error);
+    }
+  }
+
   async createUser(params: ICreateUserParams): Promise<IUser> {
     try {
       // Step 1 — Validate agent code if role is agent

--- a/tests/unit/users/user.change-password.test.ts
+++ b/tests/unit/users/user.change-password.test.ts
@@ -1,0 +1,218 @@
+// Supply env vars before env.ts runs so the validation guards do not throw
+process.env.SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+process.env.FRONTEND_RESET_PASSWORD_URL = 'https://test.example.com/reset-password';
+
+// ---------------------------------------------------------------------------
+// LoggingService mock — must be registered before any imports that trigger side effects
+// ---------------------------------------------------------------------------
+
+jest.mock('@src/services/logging.service', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+  loggingService: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+  asyncLocalStorage: {
+    getStore: jest.fn().mockReturnValue(null),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// SupabaseService mock — prevent real client instantiation
+// ---------------------------------------------------------------------------
+
+jest.mock('@src/services/supabase.service', () => ({
+  __esModule: true,
+  default: {
+    adminSelect: jest.fn(),
+    adminInsert: jest.fn(),
+    adminUpdate: jest.fn(),
+    adminDelete: jest.fn(),
+    adminCreateAuthUser: jest.fn(),
+    adminDeleteAuthUser: jest.fn(),
+    signInWithPassword: jest.fn(),
+    signOut: jest.fn(),
+    resetPasswordForEmail: jest.fn(),
+    exchangeCodeForSession: jest.fn(),
+    adminUpdateAuthUserPassword: jest.fn(),
+  },
+  supabaseService: {
+    adminSelect: jest.fn(),
+    adminInsert: jest.fn(),
+    adminUpdate: jest.fn(),
+    adminDelete: jest.fn(),
+    adminCreateAuthUser: jest.fn(),
+    adminDeleteAuthUser: jest.fn(),
+    signInWithPassword: jest.fn(),
+    signOut: jest.fn(),
+    resetPasswordForEmail: jest.fn(),
+    exchangeCodeForSession: jest.fn(),
+    adminUpdateAuthUserPassword: jest.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Sentry mock — prevent real Sentry initialisation
+// ---------------------------------------------------------------------------
+
+jest.mock('@sentry/node', () => ({
+  withScope: jest.fn((cb) => cb({ setFingerprint: jest.fn(), setLevel: jest.fn(), setExtra: jest.fn() })),
+  setTag: jest.fn(),
+  setUser: jest.fn(),
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// sentry.metrics mock — prevent real metrics calls
+// ---------------------------------------------------------------------------
+
+jest.mock('@src/utils/sentry.metrics', () => ({
+  emitErrorCount: jest.fn(),
+}));
+
+import type { Response, NextFunction } from 'express';
+
+import { userController } from '@src/controllers/user.controller';
+import type { IChangePasswordReq } from '@src/controllers/user.controller';
+import { userService } from '@src/services/user.service';
+import userRepository from '@src/repositories/user.repository';
+import supabaseService from '@src/services/supabase.service';
+import { ControllerError } from '@src/models/errors/layer.errors';
+import { ServiceError } from '@src/models/errors/layer.errors';
+import { RepositoryError } from '@src/models/errors/layer.errors';
+
+/******************************************************************************
+  Helpers
+******************************************************************************/
+
+function makeRes(): Response {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+function makeNext(): jest.Mock {
+  return jest.fn();
+}
+
+/******************************************************************************
+  Test suite — UserController.changePassword
+******************************************************************************/
+
+describe('UserController.changePassword', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('returns HTTP 200 with { success: true, message: "Password changed successfully" } on happy path', async () => {
+    jest.spyOn(userService, 'changePassword').mockResolvedValue(undefined);
+
+    const req: IChangePasswordReq = {
+      user: { id: 'user-uuid-123', tenant_id: 'tenant-uuid-456', role: 'agent' },
+      body: { newPassword: 'NewSecret1!' },
+      headers: {},
+    } as unknown as IChangePasswordReq;
+    const res = makeRes();
+    const next = makeNext();
+
+    await userController.changePassword(req, res, next as NextFunction);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Password changed successfully',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next() with ControllerError when service throws', async () => {
+    jest
+      .spyOn(userService, 'changePassword')
+      .mockRejectedValue(new ServiceError('UserService.changePassword failed', new Error('db failure')));
+
+    const req: IChangePasswordReq = {
+      user: { id: 'user-uuid-123', tenant_id: 'tenant-uuid-456', role: 'agent' },
+      body: { newPassword: 'NewSecret1!' },
+      headers: {},
+    } as unknown as IChangePasswordReq;
+    const res = makeRes();
+    const next = makeNext();
+
+    await userController.changePassword(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0][0];
+    expect(err).toBeInstanceOf(ControllerError);
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});
+
+/******************************************************************************
+  Test suite — UserService.changePassword
+******************************************************************************/
+
+describe('UserService.changePassword', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('calls userRepository.updateAuthUserPassword with correct arguments', async () => {
+    const spy = jest
+      .spyOn(userRepository, 'updateAuthUserPassword')
+      .mockResolvedValue(undefined);
+
+    await userService.changePassword('user-uuid-123', 'NewSecret1!');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('user-uuid-123', 'NewSecret1!');
+  });
+
+  it('propagates error as ServiceError when repository throws', async () => {
+    jest
+      .spyOn(userRepository, 'updateAuthUserPassword')
+      .mockRejectedValue(new RepositoryError('UserRepository.updateAuthUserPassword failed', new Error('supabase error')));
+
+    await expect(userService.changePassword('user-uuid-123', 'NewSecret1!')).rejects.toBeInstanceOf(ServiceError);
+  });
+});
+
+/******************************************************************************
+  Test suite — UserRepository.updateAuthUserPassword
+******************************************************************************/
+
+describe('UserRepository.updateAuthUserPassword', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('calls supabaseService.adminUpdateAuthUserPassword with correct arguments', async () => {
+    const mockAdminUpdateAuthUserPassword = supabaseService.adminUpdateAuthUserPassword as jest.Mock;
+    mockAdminUpdateAuthUserPassword.mockResolvedValue(undefined);
+
+    await userRepository.updateAuthUserPassword('user-uuid-123', 'NewSecret1!');
+
+    expect(mockAdminUpdateAuthUserPassword).toHaveBeenCalledTimes(1);
+    expect(mockAdminUpdateAuthUserPassword).toHaveBeenCalledWith('user-uuid-123', 'NewSecret1!');
+  });
+
+  it('propagates error as RepositoryError when supabaseService throws', async () => {
+    const mockAdminUpdateAuthUserPassword = supabaseService.adminUpdateAuthUserPassword as jest.Mock;
+    mockAdminUpdateAuthUserPassword.mockRejectedValue(new Error('network failure'));
+
+    await expect(
+      userRepository.updateAuthUserPassword('user-uuid-123', 'NewSecret1!'),
+    ).rejects.toBeInstanceOf(RepositoryError);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `PATCH /api/users/me/password` for authenticated users to change their own password
- Accepts `{ newPassword: string }` with full password strength validation (min 6, uppercase, digit, special char)
- Delegates to Supabase Admin API via the existing `adminUpdateAuthUserPassword` method

## Test plan

- [ ] Unit tests added for controller, service, and repository layers — all passing
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Manually test with a valid Bearer JWT: `PATCH /api/users/me/password` with `{ "newPassword": "NewPass1!" }` → `200 { success: true, message: 'Password changed successfully' }`
- [ ] Confirm invalid password (too short, no uppercase, etc.) returns `400` with Zod validation errors
- [ ] Confirm request without Bearer token returns `401`

🤖 Generated with [Claude Code](https://claude.com/claude-code)