### PR TITLE
feat: add maintenance mode middleware

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -32,6 +32,14 @@ app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+// Maintenance mode — returns 503 for all routes except /health
+if (EnvVars.MaintenanceMode) {
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    if (req.path === '/health') return next();
+    res.status(503).json({ message: 'System under maintenance' });
+  });
+}
+
 // Pino request-logging middleware
 // Generates a correlation ID per request, stores it in AsyncLocalStorage,
 // and logs both incoming requests and outgoing responses including headers and body.

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -24,6 +24,7 @@ const EnvVars = {
   SentryDsn: process.env.SENTRY_DSN || '',
   VercelEnv: process.env.VERCEL_ENV || '',
   DisableHelmet: process.env.DISABLE_HELMET === 'true',
+  MaintenanceMode: (process.env.MAINTENANCE_MODE || 'false') === 'true',
 };
 
 if (!EnvVars.SupabaseUrl.trim()) {


### PR DESCRIPTION
## Summary
- Adds `MAINTENANCE_MODE` env var support (defaults to `false`)
- When set to `true`, returns `503 { message: 'System under maintenance' }` for all routes except `/health`
- Toggle via Vercel env vars — no code change or revert deploy needed

## Test plan
- [ ] Set `MAINTENANCE_MODE=true` locally, verify all API routes return 503
- [ ] Verify `/health` still returns 200
- [ ] Verify normal behavior when env var is unset or `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)