### PR TITLE
feat(groups): replace member_ids with declarative set semantics

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1323,8 +1323,10 @@ paths:
         is supplied and differs from the current leader, the new leader is promoted
         to `group_leader` and the previous leader is demoted back to `agent`. When
         `trainer_ids` is supplied, the existing trainer assignments for the group are replaced with the provided set. When
-        `member_ids` is supplied, the `group_id` field on each referenced user is
-        set to this group. All referenced users must exist within the caller's tenant.
+        `member_ids` is supplied, the group's member set is **replaced** with the provided list — users currently in the
+        group but absent from the new list have their `group_id` set to `null` (unlinked). The current group leader is
+        always retained as a member regardless of whether their UUID appears in `member_ids`. Passing an empty array
+        (`[]`) unlinks all non-leader members. All provided UUIDs must exist within the caller's tenant.
       security:
         - bearerAuth: []
       parameters:
@@ -1374,13 +1376,13 @@ paths:
                     - 3fa85f64-5717-4562-b3fc-2c963f66afa6
                 member_ids:
                   type: array
-                  minItems: 1
                   items:
                     type: string
                     format: uuid
                   description: >
-                    Array of user UUIDs to assign to this group. Sets the
-                    `group_id` field on each referenced user. All provided IDs
+                    Replaces the full member set for the group. Users currently in the group but absent from this list
+                    have their `group_id` set to `null`. The current group leader is always retained regardless of
+                    whether their UUID is included. Pass `[]` to unlink all non-leader members. All provided UUIDs
                     must exist within the caller's tenant.
                   example:
                     - a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11

--- a/src/repositories/user.repository.ts
+++ b/src/repositories/user.repository.ts
@@ -286,9 +286,45 @@ class UserRepository {
     }
   }
 
+  async findByGroupId(groupId: string, userToken: string): Promise<IUser[]> {
+    try {
+      const response = await supabaseService.userSelect(
+        userToken,
+        'users',
+        '*',
+        { group_id: groupId } as Partial<UsersRow>,
+      );
+
+      if (response.error) {
+        throw new Error(response.error.message);
+      }
+
+      const rows = (response.data ?? []) as unknown as UsersRow[];
+      const users: IUser[] = rows.map((row) => ({
+        id: row.id,
+        tenant_id: row.tenant_id,
+        email: row.email,
+        name: row.name,
+        role: row.role,
+        agent_code: row.agent_code,
+        location: row.location,
+        group_id: row.group_id,
+        phone: row.phone,
+        agency: row.agency,
+        status: row.status,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+      }));
+
+      return users;
+    } catch (error) {
+      return handleRepositoryError('UserRepository.findByGroupId', error);
+    }
+  }
+
   async updateGroupIdForUsers(
     userIds: string[],
-    groupId: string,
+    groupId: string | null,
     userToken: string,
   ): Promise<void> {
     try {

--- a/src/routes/group.routes.ts
+++ b/src/routes/group.routes.ts
@@ -26,7 +26,7 @@ export const updateGroupSchema = z.object({
   status: z.enum(['active', 'inactive']).optional(),
   leader_id: z.string().uuid().optional(),
   trainer_ids: z.array(z.string().uuid()).min(1).optional(),
-  member_ids: z.array(z.string().uuid()).min(1).optional(),
+  member_ids: z.array(z.string().uuid()).optional(),
 }).strict().refine((data) => Object.keys(data).length > 0, {
   message: 'At least one field must be provided',
 });

--- a/src/services/group.service.ts
+++ b/src/services/group.service.ts
@@ -10,6 +10,7 @@ import {
 } from '@src/models/errors/group.errors';
 import authRepository from '@src/repositories/auth.repository';
 import groupRepository from '@src/repositories/group.repository';
+import userRepository from '@src/repositories/user.repository';
 import loggingService from '@src/services/logging.service';
 import userService from '@src/services/user.service';
 import { IGroup } from '@src/types/auth.types';
@@ -439,16 +440,55 @@ class GroupService {
         }
       }
 
-      // Step 4 — Members logic
-      if (data.member_ids) {
-        const foundMembers = await userService.findUsersByIds(
-          data.member_ids,
-          token,
-        );
-        if (foundMembers.length !== data.member_ids.length) {
-          throw new MissingMembersError();
+      // Step 4 — Members logic (replace semantics)
+      if (data.member_ids !== undefined) {
+        // Validate new members exist (skip if empty array)
+        if (data.member_ids.length > 0) {
+          const foundMembers = await userService.findUsersByIds(data.member_ids, token);
+          if (foundMembers.length !== data.member_ids.length) {
+            throw new MissingMembersError();
+          }
         }
-        await userService.updateUsersGroupId(data.member_ids, groupId, token);
+
+        // Effective leader — use new leader_id if being changed in this same request
+        const effectiveLeaderId = data.leader_id ?? existingGroup.leader_id;
+
+        // Fetch current members for diff and rollback
+        const currentMembers = await userRepository.findByGroupId(groupId, token);
+        const currentMemberIds = currentMembers.map((m) => m.id);
+
+        // Unlink: currently in group AND not in new list AND not the leader
+        const newMemberSet = new Set(data.member_ids);
+        const toUnlink = currentMemberIds.filter(
+          (id) => !newMemberSet.has(id) && id !== effectiveLeaderId,
+        );
+
+        // Link: in new list AND not already in this group
+        const currentMemberSet = new Set(currentMemberIds);
+        const toLink = data.member_ids.filter((id) => !currentMemberSet.has(id));
+
+        try {
+          if (toUnlink.length > 0) {
+            await userService.updateUsersGroupId(toUnlink, null, token);
+          }
+          if (toLink.length > 0) {
+            await userService.updateUsersGroupId(toLink, groupId, token);
+          }
+        } catch (memberError) {
+          // Rollback: re-link any unlinked users back to this group
+          if (toUnlink.length > 0) {
+            try {
+              await userService.updateUsersGroupId(toUnlink, groupId, token);
+            } catch (rollbackError) {
+              loggingService.error(
+                'GroupService.updateGroup — member rollback failed',
+                rollbackError,
+                { groupId },
+              );
+            }
+          }
+          throw memberError;
+        }
       }
 
       // Step 5 — Build update payload and persist (skip if nothing to update in the row)

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -183,7 +183,7 @@ class UserService {
     }
   }
 
-  async updateUsersGroupId(userIds: string[], groupId: string, token: string): Promise<void> {
+  async updateUsersGroupId(userIds: string[], groupId: string | null, token: string): Promise<void> {
     try {
       await userRepository.updateGroupIdForUsers(userIds, groupId, token);
     } catch (error) {

--- a/tests/unit/groups/group.service.test.ts
+++ b/tests/unit/groups/group.service.test.ts
@@ -51,6 +51,7 @@ import { groupService } from '@src/services/group.service';
 import { groupRepository } from '@src/repositories/group.repository';
 import { authRepository } from '@src/repositories/auth.repository';
 import { userService } from '@src/services/user.service';
+import { userRepository } from '@src/repositories/user.repository';
 import {
   GroupNotFoundError,
   InvalidLeaderError,
@@ -576,6 +577,8 @@ describe('GroupService.updateGroup', () => {
   it('calls updateUsersGroupId when member_ids are valid', async () => {
     jest.spyOn(groupRepository, 'findById').mockResolvedValue(mockGroup);
     jest.spyOn(userService, 'findUsersByIds').mockResolvedValue([mockMember1, mockMember2]);
+    // No current members in the group — both MEMBER_ID_1 and MEMBER_ID_2 go into toLink
+    jest.spyOn(userRepository, 'findByGroupId').mockResolvedValue([]);
     jest.spyOn(userService, 'updateUsersGroupId').mockResolvedValue(undefined);
 
     await groupService.updateGroup({
@@ -589,6 +592,226 @@ describe('GroupService.updateGroup', () => {
       GROUP_ID,
       USER_TOKEN,
     );
+  });
+
+  /*****************************************************************************
+    member_ids replace semantics
+  *****************************************************************************/
+
+  describe('member_ids replace semantics', () => {
+    const AGENT_A_ID = '11111111-aaaa-bbbb-cccc-dddddddddddd';
+    const AGENT_B_ID = '22222222-aaaa-bbbb-cccc-dddddddddddd';
+    const AGENT_C_ID = '33333333-aaaa-bbbb-cccc-dddddddddddd';
+    const CURRENT_LEADER_ID = '44444444-aaaa-bbbb-cccc-dddddddddddd';
+    const NEW_LEADER_ID = '55555555-aaaa-bbbb-cccc-dddddddddddd';
+
+    const makeUser = (id: string, groupId: string | null = null): IUserWithManagedGroups => ({
+      id,
+      tenant_id: TENANT_ID,
+      email: `${id}@example.com`,
+      name: `User ${id}`,
+      role: 'agent',
+      agent_code: null,
+      location: null,
+      group_id: groupId,
+      phone: null,
+      agency: null,
+      status: 'active',
+      created_at: '2024-01-01T00:00:00.000Z',
+      updated_at: '2024-01-01T00:00:00.000Z',
+      managed_group_ids: [],
+    });
+
+    const groupWithCurrentLeader: IGroup = {
+      ...mockGroup,
+      leader_id: CURRENT_LEADER_ID,
+    };
+
+    afterEach(() => jest.restoreAllMocks());
+
+    it('does not call findByGroupId or updateUsersGroupId when member_ids is not supplied', async () => {
+      jest.spyOn(groupRepository, 'findById').mockResolvedValue(mockGroup);
+      jest.spyOn(groupRepository, 'updateGroup').mockResolvedValue({ ...mockGroup, name: 'New Name' });
+      const findByGroupIdSpy = jest.spyOn(userRepository, 'findByGroupId');
+      const updateUsersGroupIdSpy = jest.spyOn(userService, 'updateUsersGroupId');
+
+      await groupService.updateGroup({
+        groupId: GROUP_ID,
+        token: USER_TOKEN,
+        data: { name: 'New Name' },
+      });
+
+      expect(findByGroupIdSpy).not.toHaveBeenCalled();
+      expect(updateUsersGroupIdSpy).not.toHaveBeenCalled();
+    });
+
+    it('member_ids: [] unlinks all non-leader members and does not call updateUsersGroupId to link', async () => {
+      const agentA = makeUser(AGENT_A_ID, GROUP_ID);
+      const agentB = makeUser(AGENT_B_ID, GROUP_ID);
+      const leader = makeUser(CURRENT_LEADER_ID, GROUP_ID);
+
+      jest.spyOn(groupRepository, 'findById').mockResolvedValue(groupWithCurrentLeader);
+      jest.spyOn(userRepository, 'findByGroupId').mockResolvedValue([agentA, agentB, leader]);
+      const updateUsersGroupIdSpy = jest.spyOn(userService, 'updateUsersGroupId').mockResolvedValue(undefined);
+
+      await groupService.updateGroup({
+        groupId: GROUP_ID,
+        token: USER_TOKEN,
+        data: { member_ids: [] },
+      });
+
+      // Only called once to unlink agentA and agentB — leader is protected
+      expect(updateUsersGroupIdSpy).toHaveBeenCalledTimes(1);
+      expect(updateUsersGroupIdSpy).toHaveBeenCalledWith(
+        expect.arrayContaining([AGENT_A_ID, AGENT_B_ID]),
+        null,
+        USER_TOKEN,
+      );
+      // Confirm leader ID is absent from the unlink call
+      const [unlinkedIds] = updateUsersGroupIdSpy.mock.calls[0];
+      expect(unlinkedIds).not.toContain(CURRENT_LEADER_ID);
+    });
+
+    it('partial replace: adds new member, removes removed member, keeps leader and unchanged member untouched', async () => {
+      const agentA = makeUser(AGENT_A_ID, null);       // not in group — will be added
+      const agentB = makeUser(AGENT_B_ID, GROUP_ID);   // already in group — unchanged
+      const agentC = makeUser(AGENT_C_ID, GROUP_ID);   // in group — will be removed
+      const leader = makeUser(CURRENT_LEADER_ID, GROUP_ID); // leader — always kept
+
+      jest.spyOn(groupRepository, 'findById').mockResolvedValue(groupWithCurrentLeader);
+      // findUsersByIds is called for the non-empty member_ids validation step
+      jest.spyOn(userService, 'findUsersByIds').mockResolvedValue([agentA, agentB]);
+      jest.spyOn(userRepository, 'findByGroupId').mockResolvedValue([agentB, agentC, leader]);
+      const updateUsersGroupIdSpy = jest.spyOn(userService, 'updateUsersGroupId').mockResolvedValue(undefined);
+
+      await groupService.updateGroup({
+        groupId: GROUP_ID,
+        token: USER_TOKEN,
+        data: { member_ids: [AGENT_A_ID, AGENT_B_ID] },
+      });
+
+      // Unlink agentC (not in new list, not the leader)
+      expect(updateUsersGroupIdSpy).toHaveBeenCalledWith([AGENT_C_ID], null, USER_TOKEN);
+      // Link agentA (in new list but not currently in group)
+      expect(updateUsersGroupIdSpy).toHaveBeenCalledWith([AGENT_A_ID], GROUP_ID, USER_TOKEN);
+      // agentB and leader must never appear in any call
+      const allCalledIds = updateUsersGroupIdSpy.mock.calls.flatMap(([ids]) => ids);
+      expect(allCalledIds).not.toContain(AGENT_B_ID);
+      expect(allCalledIds).not.toContain(CURRENT_LEADER_ID);
+    });
+
+    it('throws MissingMembersError when a supplied UUID does not exist — findByGroupId not called', async () => {
+      jest.spyOn(groupRepository, 'findById').mockResolvedValue(groupWithCurrentLeader);
+      // Return only agentA — nonExistentId is missing
+      jest.spyOn(userService, 'findUsersByIds').mockResolvedValue([makeUser(AGENT_A_ID)]);
+      const findByGroupIdSpy = jest.spyOn(userRepository, 'findByGroupId');
+
+      const NON_EXISTENT_ID = 'ffffffff-ffff-ffff-ffff-000000000000';
+
+      await expect(
+        groupService.updateGroup({
+          groupId: GROUP_ID,
+          token: USER_TOKEN,
+          data: { member_ids: [AGENT_A_ID, NON_EXISTENT_ID] },
+        }),
+      ).rejects.toBeInstanceOf(MissingMembersError);
+
+      expect(findByGroupIdSpy).not.toHaveBeenCalled();
+    });
+
+    it('new leader is auto-protected: when leader_id changes, old leader is unlinked along with other non-new-leader members', async () => {
+      const agentA = makeUser(AGENT_A_ID, GROUP_ID);
+      const oldLeader = makeUser(CURRENT_LEADER_ID, GROUP_ID);
+      // New leader validated via getUserById in leader step
+      const newLeaderUser = { ...makeUser(NEW_LEADER_ID), role: 'agent' };
+
+      const groupWithOldLeaderFixture: IGroup = { ...mockGroup, leader_id: CURRENT_LEADER_ID };
+
+      jest.spyOn(groupRepository, 'findById').mockResolvedValue(groupWithOldLeaderFixture);
+      // Leader step — validate new leader
+      jest.spyOn(userService, 'getUserById').mockResolvedValue(newLeaderUser);
+      jest.spyOn(userService, 'updateUser').mockResolvedValue({ ...newLeaderUser, role: 'group_leader' });
+      // member_ids: [] — no members to validate via findUsersByIds
+      jest.spyOn(userRepository, 'findByGroupId').mockResolvedValue([agentA, oldLeader]);
+      const updateUsersGroupIdSpy = jest.spyOn(userService, 'updateUsersGroupId').mockResolvedValue(undefined);
+      jest.spyOn(groupRepository, 'updateGroup').mockResolvedValue({
+        ...groupWithOldLeaderFixture,
+        leader_id: NEW_LEADER_ID,
+      });
+
+      await groupService.updateGroup({
+        groupId: GROUP_ID,
+        token: USER_TOKEN,
+        data: { leader_id: NEW_LEADER_ID, member_ids: [] },
+      });
+
+      // effectiveLeaderId = NEW_LEADER_ID (the incoming leader_id)
+      // toUnlink = [agentA, oldLeader] — neither is the new leader; old leader loses protection
+      expect(updateUsersGroupIdSpy).toHaveBeenCalledWith(
+        expect.arrayContaining([AGENT_A_ID, CURRENT_LEADER_ID]),
+        null,
+        USER_TOKEN,
+      );
+      const [unlinkedIds] = updateUsersGroupIdSpy.mock.calls[0];
+      expect(unlinkedIds).not.toContain(NEW_LEADER_ID);
+    });
+
+    it('rollback: re-links toUnlink users if the link step throws', async () => {
+      const agentA = makeUser(AGENT_A_ID, null);       // to be linked
+      const agentC = makeUser(AGENT_C_ID, GROUP_ID);   // to be unlinked
+
+      jest.spyOn(groupRepository, 'findById').mockResolvedValue(groupWithCurrentLeader);
+      jest.spyOn(userService, 'findUsersByIds').mockResolvedValue([agentA]);
+      jest.spyOn(userRepository, 'findByGroupId').mockResolvedValue([agentC, makeUser(CURRENT_LEADER_ID, GROUP_ID)]);
+
+      const linkError = new Error('link step failed');
+      const updateUsersGroupIdSpy = jest.spyOn(userService, 'updateUsersGroupId')
+        .mockResolvedValueOnce(undefined)  // unlink agentC succeeds
+        .mockRejectedValueOnce(linkError)  // link agentA fails
+        .mockResolvedValueOnce(undefined); // rollback re-link agentC succeeds
+
+      await expect(
+        groupService.updateGroup({
+          groupId: GROUP_ID,
+          token: USER_TOKEN,
+          data: { member_ids: [AGENT_A_ID] },
+        }),
+      ).rejects.toThrow();
+
+      // Third call: rollback re-links agentC back to group
+      expect(updateUsersGroupIdSpy).toHaveBeenCalledTimes(3);
+      expect(updateUsersGroupIdSpy).toHaveBeenNthCalledWith(3, [AGENT_C_ID], GROUP_ID, USER_TOKEN);
+    });
+
+    it('rollback failure: logs error containing "member rollback failed" and original error still bubbles', async () => {
+      const agentA = makeUser(AGENT_A_ID, null);
+      const agentC = makeUser(AGENT_C_ID, GROUP_ID);
+
+      jest.spyOn(groupRepository, 'findById').mockResolvedValue(groupWithCurrentLeader);
+      jest.spyOn(userService, 'findUsersByIds').mockResolvedValue([agentA]);
+      jest.spyOn(userRepository, 'findByGroupId').mockResolvedValue([agentC, makeUser(CURRENT_LEADER_ID, GROUP_ID)]);
+
+      const originalError = new Error('link step failed');
+      const rollbackError = new Error('rollback also failed');
+      jest.spyOn(userService, 'updateUsersGroupId')
+        .mockResolvedValueOnce(undefined)        // unlink agentC succeeds
+        .mockRejectedValueOnce(originalError)    // link agentA fails
+        .mockRejectedValueOnce(rollbackError);   // rollback also fails
+
+      await expect(
+        groupService.updateGroup({
+          groupId: GROUP_ID,
+          token: USER_TOKEN,
+          data: { member_ids: [AGENT_A_ID] },
+        }),
+      ).rejects.toThrow();
+
+      expect(mockLoggingError).toHaveBeenCalledWith(
+        expect.stringContaining('member rollback failed'),
+        rollbackError,
+        expect.objectContaining({ groupId: GROUP_ID }),
+      );
+    });
   });
 
   it('returns existingGroup directly when updatePayload is empty (only trainer_ids/member_ids sent)', async () => {


### PR DESCRIPTION
## Summary

Closes #46

Changes `member_ids` in `PUT /groups/:groupId` from additive to **replace semantics**, making it symmetric with the existing `trainer_ids` behavior.

- Supplying `member_ids` now sets the group's complete member set — users currently in the group but absent from the new list have `group_id` set to `null`
- Passing `[]` unlinks all non-leader members
- The current group leader is always retained regardless of whether their UUID appears in `member_ids`
- If `leader_id` is also changing in the same request, the *new* leader is auto-retained
- Rollback: if the link step fails after a successful unlink, unlinked users are re-linked

## Changes

- **`src/routes/group.routes.ts`** — dropped `min(1)` from `member_ids` schema; `[]` is now valid
- **`src/repositories/user.repository.ts`** — added `findByGroupId`; `updateGroupIdForUsers` now accepts `string | null`
- **`src/services/user.service.ts`** — `updateUsersGroupId` second arg relaxed to `string | null`
- **`src/services/group.service.ts`** — diff-based replace with rollback replaces the old additive block
- **`tests/unit/groups/group.service.test.ts`** — 7 new unit tests for replace semantics
- **`openapi.yaml`** — updated `member_ids` description; removed `minItems: 1`

## Test plan

- [ ] `npm test -- --testPathPatterns=groups` — all 7 new tests pass
- [ ] `PUT /groups/:id` with `{ "member_ids": [] }` → all non-leader members unlinked, leader unaffected
- [ ] `PUT /groups/:id` with a partial list → absent members unlinked, new members linked, unchanged members untouched
- [ ] `PUT /groups/:id` with unknown UUID → `MissingMembersError`
- [ ] `PUT /groups/:id` with both `leader_id` and `member_ids: []` → new leader retained, old leader unlinked

🤖 Generated with [Claude Code](https://claude.com/claude-code)