### PR TITLE
feat: agent event management and public event endpoint

### DIFF
--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -10,6 +10,11 @@ You are an experienced TypeScript developer specialising in building REST APIs
 following layered architecture. Your sole responsibility is to create and run
 unit and feature tests for the APIs implemented.
 
+## Tooling
+* For project CLIs, always use `npx <tool> ...` (e.g. `npx supabase migration up`).
+* NEVER invoke binaries directly from `node_modules/.bin/` or `node_modules/<pkg>/.bin/`.
+* Prefer the simplest standard invocation — don't construct exotic paths to executables.
+
 ## Workflow
 1. Run `git diff HEAD` to identify exactly which files have changed. Scope your
    tests only to those changes — do not write tests for unrelated code.

--- a/.claude/agents/tester.md
+++ b/.claude/agents/tester.md
@@ -12,8 +12,26 @@ unit and feature tests for the APIs implemented.
 
 ## Tooling
 * For project CLIs, always use `npx <tool> ...` (e.g. `npx supabase migration up`).
+* Supabase CLI must be invoked via `npx supabase`. It is not installed globally.
 * NEVER invoke binaries directly from `node_modules/.bin/` or `node_modules/<pkg>/.bin/`.
 * Prefer the simplest standard invocation — don't construct exotic paths to executables.
+* Migrations run against the LOCAL database ONLY (`npx supabase migration up --local`).
+  NEVER run migrations against a linked/remote project — no `--linked`, no `db push`,
+  no `--db-url` pointing at anything other than local.
+
+## Test Data
+* Use the seeded test data in `scripts/seed-manifest.json` for all tests — do NOT
+  fabricate user IDs, tenant IDs, group IDs, agent codes, or emails.
+* The manifest exposes the demo tenant, login passwords, and a roster of users
+  per role (`admin`, `master_trainer`, `trainer`, `group_leader`, `agent`) across
+  three groups (`mdrt_stars`, `kpi_busters`, `power_rangers`). Pick the user whose
+  role matches the scenario you are testing.
+* Read the manifest at the start of the test file (or in `beforeAll`) and reference
+  values from it. Never hardcode duplicates of the same data inline.
+* NEVER reset the database. Do NOT run `supabase db reset`, `supabase db push --reset`,
+  re-seed scripts, truncate tables, or any command that wipes existing data. The
+  seeded data must remain intact across test runs. Tests must clean up only the
+  records they themselves created (track IDs and delete in `afterAll`).
 
 ## Workflow
 1. Run `git diff HEAD` to identify exactly which files have changed. Scope your

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -34,22 +34,29 @@ jobs:
         working-directory: vistaq_client
         run: npm run gen:types
 
-      - name: Open PR on frontend
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.FRONTEND_REPO_PAT }}
-          path: vistaq_client
-          branch: chore/sync-openapi-spec
-          base: staging
-          title: "chore: sync OpenAPI spec from backend"
-          body: |
-            Automated sync triggered by a change to `openapi.yaml` on the backend.
+      - name: Commit and push
+        working-directory: vistaq_client
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B chore/sync-openapi-spec
+          git add openapi.yaml types.generated.ts
+          git diff --staged --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore: sync openapi spec and regenerate types"
+          git push origin chore/sync-openapi-spec --force
 
-            **Backend commit:** [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+      - name: Open PR if one does not exist
+        env:
+          GH_TOKEN: ${{ secrets.FRONTEND_REPO_PAT }}
+        run: |
+          gh pr create \
+            --repo VistaQ/vistaq_client \
+            --head chore/sync-openapi-spec \
+            --base staging \
+            --title "chore: sync OpenAPI spec from backend" \
+            --body "Automated sync triggered by backend commit [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}).
 
-            Changes included:
-            - `openapi.yaml` — updated spec copied from backend
-            - `types.generated.ts` — regenerated via `npm run gen:types`
-
-            Review the type changes and merge when the frontend is ready to consume them.
-          commit-message: "chore: sync openapi spec and regenerate types"
+          Changes:
+          - \`openapi.yaml\` — updated spec from backend
+          - \`types.generated.ts\` — regenerated via \`npm run gen:types\`" \
+          || true

--- a/.github/workflows/sync-openapi.yml
+++ b/.github/workflows/sync-openapi.yml
@@ -1,0 +1,55 @@
+name: Sync OpenAPI spec to frontend
+
+on:
+  push:
+    branches:
+      - staging
+    paths:
+      - openapi.yaml
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout backend
+        uses: actions/checkout@v4
+
+      - name: Checkout frontend
+        uses: actions/checkout@v4
+        with:
+          repository: VistaQ/vistaq_client
+          token: ${{ secrets.FRONTEND_REPO_PAT }}
+          path: vistaq_client
+          ref: staging
+
+      - name: Copy openapi.yaml to frontend
+        run: cp openapi.yaml vistaq_client/openapi.yaml
+
+      - name: Install frontend dependencies
+        working-directory: vistaq_client
+        run: npm ci
+
+      - name: Regenerate types
+        working-directory: vistaq_client
+        run: npm run gen:types
+
+      - name: Open PR on frontend
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.FRONTEND_REPO_PAT }}
+          path: vistaq_client
+          branch: chore/sync-openapi-spec
+          base: staging
+          title: "chore: sync OpenAPI spec from backend"
+          body: |
+            Automated sync triggered by a change to `openapi.yaml` on the backend.
+
+            **Backend commit:** [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+
+            Changes included:
+            - `openapi.yaml` — updated spec copied from backend
+            - `types.generated.ts` — regenerated via `npm run gen:types`
+
+            Review the type changes and merge when the frontend is ready to consume them.
+          commit-message: "chore: sync openapi spec and regenerate types"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2038,11 +2038,14 @@ paths:
       description: >
         Creates a new event scoped to the authenticated user's tenant. The caller
         must supply a valid Bearer token belonging to a user with the `admin`,
-        `master_trainer`, `trainer`, or `group_leader` role — `agent` users will
-        receive a 403. At least one of `groupIds` or `agentIds` must be provided.
-        For `trainer` users, all supplied `groupIds` must belong to groups that
-        the trainer manages via the `group_trainers` junction table; any unmanaged
-        group IDs result in a 400.
+        `master_trainer`, `trainer`, `group_leader`, or `agent` role. At least
+        one of `groupIds` or `agentIds` must be provided for non-`agent` roles —
+        `agent` users are automatically assigned to their own event and may omit
+        both fields. For `trainer` users, all supplied `groupIds` must belong to
+        groups that the trainer manages via the `group_trainers` junction table;
+        any unmanaged group IDs result in a 400. If `visibility` is not supplied,
+        it defaults to `public` for `agent` and `group_leader` roles, and
+        `private` for all other roles.
       security:
         - bearerAuth: []
       requestBody:
@@ -2105,6 +2108,13 @@ paths:
                   minLength: 1
                   description: Description or agenda for the event.
                   example: Quarterly training kickoff covering Q2 targets and new product modules.
+                visibility:
+                  type: string
+                  enum: [public, private]
+                  description: >
+                    Visibility of the event. Optional. Defaults to `public` for `agent`
+                    and `group_leader` roles, `private` for all other roles.
+                  example: public
                 groupIds:
                   type: array
                   minItems: 1
@@ -2115,7 +2125,9 @@ paths:
                     Array of group UUIDs the event is associated with. Must
                     contain at least one UUID if provided, and must not contain
                     duplicates. For trainers, all IDs must be groups they manage.
-                    At least one of `groupIds` or `agentIds` must be supplied.
+                    At least one of `groupIds` or `agentIds` must be supplied
+                    (ignored for `agent` role — agents are always assigned to
+                    their own event automatically).
                   example:
                     - 7c9e6679-7425-40de-944b-e07fc1f90ae7
                 agentIds:
@@ -2128,7 +2140,9 @@ paths:
                     Array of agent user UUIDs to assign individually to the
                     event via the `event_agents` junction table. Must contain at
                     least one UUID if provided, and must not contain duplicates.
-                    At least one of `groupIds` or `agentIds` must be supplied.
+                    At least one of `groupIds` or `agentIds` must be supplied
+                    (ignored for `agent` role — agents are always assigned to
+                    their own event automatically).
                   example:
                     - a1b2c3d4-e5f6-7890-abcd-ef1234567890
       responses:
@@ -2194,8 +2208,7 @@ paths:
                 message: Unauthorized
         '403':
           description: >
-            Forbidden. Returned when the authenticated user has the `agent`
-            role, which is not permitted to create events.
+            Forbidden — non-admin attempting to modify another user's event.
           content:
             application/json:
               schema:
@@ -2315,13 +2328,16 @@ paths:
       description: >
         Updates the event identified by `eventId`. The caller must supply a valid
         Bearer token belonging to a user with the `admin`, `master_trainer`,
-        `trainer`, or `group_leader` role — `agent` users will receive a 403.
-        All request body fields are optional, but at least one must be provided.
-        When `groupIds` is supplied, the existing `event_groups` entries for this
-        event are replaced entirely. When `agentIds` is supplied, the existing
-        `event_agents` entries for this event are replaced entirely. For `trainer`
-        users, all supplied `groupIds` must belong to groups they manage; any
-        unmanaged group IDs result in a 400.
+        `trainer`, `group_leader`, or `agent` role. All request body fields are
+        optional, but at least one must be provided. Non-admin users may only
+        update events they created — attempting to modify another user's event
+        returns a 403. `agent` users always remain the sole assigned agent;
+        supplied `groupIds` and `agentIds` are ignored and replaced with the
+        agent's own ID. When `groupIds` is supplied (non-`agent` roles), the
+        existing `event_groups` entries for this event are replaced entirely.
+        When `agentIds` is supplied, the existing `event_agents` entries for this
+        event are replaced entirely. For `trainer` users, all supplied `groupIds`
+        must belong to groups they manage; any unmanaged group IDs result in a 400.
       security:
         - bearerAuth: []
       parameters:
@@ -2383,6 +2399,14 @@ paths:
                   minLength: 1
                   description: Updated description or agenda for the event.
                   example: Updated agenda covering revised Q2 targets.
+                visibility:
+                  type: string
+                  enum: [public, private]
+                  description: >
+                    Updated visibility of the event. Optional. Defaults to `public`
+                    for `agent` and `group_leader` roles, `private` for all other
+                    roles when not supplied on creation.
+                  example: public
                 groupIds:
                   type: array
                   minItems: 1
@@ -2393,7 +2417,7 @@ paths:
                     Replacement set of group UUIDs for the event. Existing
                     `event_groups` entries are deleted and replaced with these
                     values. Must not contain duplicates. For trainers, all IDs
-                    must be groups they manage.
+                    must be groups they manage. Ignored for `agent` role.
                   example:
                     - 7c9e6679-7425-40de-944b-e07fc1f90ae7
                 agentIds:
@@ -2405,7 +2429,7 @@ paths:
                   description: >
                     Replacement set of agent user UUIDs for the event. Existing
                     `event_agents` entries are deleted and replaced with these
-                    values. Must not contain duplicates.
+                    values. Must not contain duplicates. Ignored for `agent` role.
                   example:
                     - a1b2c3d4-e5f6-7890-abcd-ef1234567890
       responses:
@@ -2467,8 +2491,7 @@ paths:
                 message: Unauthorized
         '403':
           description: >
-            Forbidden. Returned when the authenticated user has the `agent`
-            role, which is not permitted to update events.
+            Forbidden — non-admin attempting to modify another user's event.
           content:
             application/json:
               schema:
@@ -2482,6 +2505,140 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
+                message: Event not found
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    delete:
+      tags: [Events]
+      summary: Delete an event
+      description: >
+        Permanently deletes the event identified by `eventId`. The caller must
+        supply a valid Bearer token. Admin users may delete any event within
+        the tenant. Non-admin users may only delete events they themselves
+        created — attempting to delete another user's event returns a 403.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: eventId
+          in: path
+          required: true
+          description: UUID of the event to delete.
+          schema:
+            type: string
+            format: uuid
+            example: b2c3d4e5-f6a7-8901-bcde-f12345678901
+      responses:
+        '204':
+          description: Event deleted successfully. No response body is returned.
+        '401':
+          description: >
+            Unauthorized. Returned when the `Authorization` header is absent,
+            malformed, or contains an invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Unauthorized
+        '403':
+          description: >
+            Forbidden — non-admin attempting to delete another user's event.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Forbidden
+        '404':
+          description: Not found. Returned when no event exists for the given `eventId`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Event not found
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /events/{eventId}/public:
+    get:
+      tags: [Events]
+      summary: Get public event details
+      description: >
+        Returns publicly visible details for a single event. No authentication
+        is required. Returns 404 if the event does not exist, has been cancelled,
+        or has `visibility` set to `private`. Successful responses include a
+        `Cache-Control: public, max-age=60` header.
+      security: []
+      parameters:
+        - name: eventId
+          in: path
+          required: true
+          description: UUID of the event to retrieve.
+          schema:
+            type: string
+            format: uuid
+            example: b2c3d4e5-f6a7-8901-bcde-f12345678901
+      responses:
+        '200':
+          description: Public event details retrieved successfully.
+          headers:
+            Cache-Control:
+              description: Instructs clients and proxies to cache the response for 60 seconds.
+              schema:
+                type: string
+                example: 'public, max-age=60'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, data]
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/PublicEventObject'
+              example:
+                success: true
+                data:
+                  id: b2c3d4e5-f6a7-8901-bcde-f12345678901
+                  event_title: Q2 Agent Networking Night
+                  description: A networking event open to all agents in the region.
+                  start_date: '2026-06-01T18:00:00.000Z'
+                  end_date: '2026-06-01T21:00:00.000Z'
+                  type: 'Face to Face'
+                  venue: Marina Bay Sands Convention Centre
+                  meeting_link: null
+                  created_by_name: Jane Doe
+                  status: upcoming
+        '404':
+          description: >
+            Not found. Returned when no event exists for the given `eventId`,
+            the event has been cancelled, or the event is not public.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, message]
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: Event not found
+              example:
+                success: false
                 message: Event not found
         '500':
           description: Internal server error
@@ -4642,6 +4799,11 @@ components:
           type: string
           format: date-time
           example: '2026-03-14T08:00:00.000Z'
+        visibility:
+          type: string
+          enum: [public, private]
+          description: Visibility of the event. Defaults to `public` for `agent` and `group_leader` roles, `private` for all other roles.
+          example: private
         groupIds:
           type: array
           items:
@@ -4660,6 +4822,56 @@ components:
           example:
             - d4e5f6a7-b8c9-0123-def0-234567890123
             - e5f6a7b8-c9d0-1234-ef01-345678901234
+
+    PublicEventObject:
+      type: object
+      required:
+        - id
+        - event_title
+        - start_date
+        - type
+        - created_by_name
+        - status
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: b2c3d4e5-f6a7-8901-bcde-f12345678901
+        event_title:
+          type: string
+          example: Q2 Agent Networking Night
+        description:
+          type: string
+          nullable: true
+          example: A networking event open to all agents in the region.
+        start_date:
+          type: string
+          format: date-time
+          example: '2026-06-01T18:00:00.000Z'
+        end_date:
+          type: string
+          format: date-time
+          nullable: true
+          example: '2026-06-01T21:00:00.000Z'
+        type:
+          type: string
+          enum: ['Online', 'Face to Face']
+          example: 'Face to Face'
+        venue:
+          type: string
+          nullable: true
+          example: Marina Bay Sands Convention Centre
+        meeting_link:
+          type: string
+          nullable: true
+          example: 'https://meet.example.com/q2-networking'
+        created_by_name:
+          type: string
+          example: Jane Doe
+        status:
+          type: string
+          enum: [upcoming, completed]
+          example: upcoming
 
     DashboardStatsObject:
       type: object

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -1,7 +1,9 @@
-import { NextFunction, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
+import { z } from 'zod';
 
 import {
   EventNotFoundError,
+  ForbiddenEventAccessError,
   InvalidAgentIdsError,
   InvalidDateRangeError,
   InvalidGroupIdsError,
@@ -10,7 +12,7 @@ import {
 import { RouteError } from '@src/models/errors/route.error';
 import { IBaseReq, IBaseRes } from '@src/models/interfaces/base.interface';
 import eventService from '@src/services/event.service';
-import { IEvent } from '@src/types/event.types';
+import { IEvent, IPublicEvent } from '@src/types/event.types';
 import { handleControllerError } from '@src/utils/errorHandlers';
 import HttpStatusCodes from '@src/utils/HttpStatusCodes';
 
@@ -28,6 +30,7 @@ export interface ICreateEventReq extends IBaseReq {
     link?: string;
     venue?: string;
     description: string;
+    visibility?: string;
     groupIds?: string[];
     agentIds?: string[];
   };
@@ -49,6 +52,7 @@ export interface IUpdateEventReq extends IBaseReq {
     link?: string;
     venue?: string;
     description?: string;
+    visibility?: string;
     groupIds?: string[];
     agentIds?: string[];
   };
@@ -73,11 +77,16 @@ export interface IGetEventByIdRes extends IBaseRes {
   data: IEvent;
 }
 
+export interface IGetPublicEventRes extends IBaseRes {
+  success: boolean;
+  data: IPublicEvent;
+}
+
 /******************************************************************************
                             EventController
 ******************************************************************************/
 
-const ALLOWED_ROLES = ['admin', 'master_trainer', 'trainer', 'group_leader'];
+const ALLOWED_ROLES = ['admin', 'master_trainer', 'trainer', 'group_leader', 'agent'];
 
 class EventController {
   async create(
@@ -92,8 +101,20 @@ class EventController {
       }
 
       const token = req.headers['authorization']!.slice(7);
-      const { title, startDate, endDate, status, type, link, venue, description, groupIds, agentIds } =
-        req.body;
+      const { title, startDate, endDate, status, type, link, venue, description } = req.body;
+      let { visibility, groupIds, agentIds } = req.body;
+
+      if (req.user!.role === 'agent') {
+        groupIds = undefined;
+        agentIds = [req.user!.id];
+      } else if (groupIds === undefined && agentIds === undefined) {
+        next(new RouteError(HttpStatusCodes.BAD_REQUEST, 'At least one of groupIds or agentIds must be provided'));
+        return;
+      }
+
+      if (visibility === undefined) {
+        visibility = req.user!.role === 'agent' ? 'public' : 'private';
+      }
 
       const event = await eventService.createEvent({
         title,
@@ -104,6 +125,7 @@ class EventController {
         link,
         venue,
         description,
+        visibility,
         groupIds,
         agentIds,
         tenantId: req.user!.tenant_id,
@@ -145,8 +167,13 @@ class EventController {
 
       const token = req.headers['authorization']!.slice(7);
       const { eventId } = req.params;
-      const { title, startDate, endDate, status, type, link, venue, description, groupIds, agentIds } =
-        req.body;
+      const { title, startDate, endDate, status, type, link, venue, description, visibility } = req.body;
+      let { groupIds, agentIds } = req.body;
+
+      if (req.user!.role === 'agent') {
+        groupIds = undefined;
+        agentIds = [req.user!.id];
+      }
 
       const event = await eventService.updateEvent({
         eventId,
@@ -158,6 +185,7 @@ class EventController {
         link,
         venue,
         description,
+        visibility,
         groupIds,
         agentIds,
         tenantId: req.user!.tenant_id,
@@ -229,6 +257,63 @@ class EventController {
       res.status(HttpStatusCodes.OK).json(responseBody);
     } catch (error) {
       return handleControllerError('EventController.getById', error, next);
+    }
+  }
+
+  async delete(
+    req: IGetEventByIdReq,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const token = req.headers['authorization']!.slice(7);
+      const { eventId } = req.params;
+
+      await eventService.deleteEvent({
+        eventId,
+        userId: req.user!.id,
+        role: req.user!.role,
+        token,
+      });
+
+      res.status(HttpStatusCodes.NO_CONTENT).send();
+    } catch (error) {
+      if (error instanceof EventNotFoundError) {
+        next(new RouteError(HttpStatusCodes.NOT_FOUND, error.message));
+        return;
+      }
+      if (error instanceof ForbiddenEventAccessError) {
+        next(new RouteError(HttpStatusCodes.FORBIDDEN, error.message));
+        return;
+      }
+      return handleControllerError('EventController.delete', error, next);
+    }
+  }
+
+  async getPublic(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const parsed = z.string().uuid().safeParse(req.params.eventId);
+      if (!parsed.success) {
+        res.status(HttpStatusCodes.NOT_FOUND).json({ success: false, message: 'Event not found' });
+        return;
+      }
+
+      const event = await eventService.getPublicEventById(parsed.data);
+
+      if (!event) {
+        res.status(HttpStatusCodes.NOT_FOUND).json({ success: false, message: 'Event not found' });
+        return;
+      }
+
+      const responseBody: IGetPublicEventRes = { success: true, data: event };
+      res.setHeader('Cache-Control', 'public, max-age=60');
+      res.status(HttpStatusCodes.OK).json(responseBody);
+    } catch (error) {
+      return handleControllerError('EventController.getPublic', error, next);
     }
   }
 }

--- a/src/models/errors/event.errors.ts
+++ b/src/models/errors/event.errors.ts
@@ -36,3 +36,10 @@ export class InvalidDateRangeError extends Error {
     this.name = 'InvalidDateRangeError';
   }
 }
+
+export class ForbiddenEventAccessError extends Error {
+  public constructor(message = 'Forbidden') {
+    super(message);
+    this.name = 'ForbiddenEventAccessError';
+  }
+}

--- a/src/repositories/event.repository.ts
+++ b/src/repositories/event.repository.ts
@@ -15,6 +15,20 @@ type EventWithRelationsRow = EventsRow & {
   event_agents: { user_id: string }[];
 };
 
+export type PublicEventRaw = {
+  id: string;
+  event_title: string;
+  description: string | null;
+  start_date: string;
+  end_date: string | null;
+  type: string;
+  venue: string | null;
+  meeting_link: string | null;
+  created_by_name: string;
+  status: string;
+  visibility: string;
+};
+
 /******************************************************************************
                             EventRepository
 ******************************************************************************/
@@ -36,6 +50,7 @@ class EventRepository {
       created_by_role: row.created_by_role,
       created_at: row.created_at,
       updated_at: row.updated_at,
+      visibility: row.visibility,
       groupIds: (row.event_groups ?? []).map((eg) => eg.group_id),
       agentIds: (row.event_agents ?? []).map((ea) => ea.user_id),
     };
@@ -57,6 +72,7 @@ class EventRepository {
       created_by_role: row.created_by_role,
       created_at: row.created_at,
       updated_at: row.updated_at,
+      visibility: row.visibility,
       groupIds: [],
       agentIds: [],
     };
@@ -309,6 +325,70 @@ class EventRepository {
         'EventRepository.deleteEventAgentsByEventId',
         error,
       );
+    }
+  }
+
+  async deleteEvent(eventId: string, userToken: string): Promise<void> {
+    try {
+      const response = await supabaseService.userDelete(
+        userToken,
+        'events',
+        { id: eventId } as Partial<EventsRow>,
+      );
+
+      if (response.error) {
+        throw new Error(response.error.message);
+      }
+    } catch (error) {
+      return handleRepositoryError('EventRepository.deleteEvent', error);
+    }
+  }
+
+  async findPublicEventById(eventId: string): Promise<PublicEventRaw | null> {
+    try {
+      const response = await supabaseService.adminSelectWithJoin(
+        'events',
+        'id, event_title, description, start_date, end_date, type, venue, meeting_link, status, visibility, users!events_created_by_fkey(name)',
+        { id: eventId },
+      );
+
+      if (response.error) {
+        throw new Error(response.error.message);
+      }
+
+      if (!response.data || response.data.length === 0) {
+        return null;
+      }
+
+      const row = response.data[0] as unknown as {
+        id: string;
+        event_title: string;
+        description: string | null;
+        start_date: string;
+        end_date: string | null;
+        type: string;
+        venue: string | null;
+        meeting_link: string | null;
+        status: string;
+        visibility: string;
+        users: { name: string } | null;
+      };
+
+      return {
+        id: row.id,
+        event_title: row.event_title,
+        description: row.description,
+        start_date: row.start_date,
+        end_date: row.end_date,
+        type: row.type,
+        venue: row.venue,
+        meeting_link: row.meeting_link,
+        created_by_name: row.users?.name ?? '',
+        status: row.status,
+        visibility: row.visibility,
+      };
+    } catch (error) {
+      return handleRepositoryError('EventRepository.findPublicEventById', error);
     }
   }
 }

--- a/src/routes/event.routes.ts
+++ b/src/routes/event.routes.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 
 import eventController, {
@@ -35,6 +35,7 @@ export const createEventSchema = z
     link: z.string().url('Link must be a valid URL').optional(),
     venue: z.string().optional(),
     description: z.string().min(1),
+    visibility: z.enum(['public', 'private']).optional(),
     groupIds: z
       .array(z.string().uuid())
       .min(1)
@@ -47,10 +48,6 @@ export const createEventSchema = z
       .optional(),
   })
   .strict()
-  .refine(
-    (data) => data.groupIds !== undefined || data.agentIds !== undefined,
-    { message: 'At least one of groupIds or agentIds must be provided' },
-  )
   .refine(
     (data) => new Date(data.endDate) > new Date(data.startDate),
     { message: 'endDate must be after startDate', path: ['endDate'] },
@@ -66,6 +63,7 @@ export const updateEventSchema = z
     link: z.string().url('Link must be a valid URL').optional(),
     venue: z.string().optional(),
     description: z.string().min(1).optional(),
+    visibility: z.enum(['public', 'private']).optional(),
     groupIds: z
       .array(z.string().uuid())
       .min(1)
@@ -97,6 +95,12 @@ export const updateEventSchema = z
 
 const router = express.Router();
 
+router.get(
+  '/:eventId/public',
+  (req: Request, res: Response, next: NextFunction) =>
+    eventController.getPublic(req, res, next),
+);
+
 router.post(
   '/',
   authenticate,
@@ -111,6 +115,13 @@ router.put(
   validate(updateEventSchema),
   (req, res, next) =>
     eventController.update(req as unknown as IUpdateEventReq, res, next),
+);
+
+router.delete(
+  '/:eventId',
+  authenticate,
+  (req, res, next) =>
+    eventController.delete(req as unknown as IGetEventByIdReq, res, next),
 );
 
 router.get(

--- a/src/services/event.service.ts
+++ b/src/services/event.service.ts
@@ -1,12 +1,13 @@
 import {
   EventNotFoundError,
+  ForbiddenEventAccessError,
   InvalidAgentIdsError,
   InvalidDateRangeError,
   InvalidGroupIdsError,
   UnauthorizedGroupAccessError,
 } from '@src/models/errors/event.errors';
 import eventRepository from '@src/repositories/event.repository';
-import { IEvent } from '@src/types/event.types';
+import { IEvent, IPublicEvent } from '@src/types/event.types';
 import { handleServiceError } from '@src/utils/errorHandlers';
 import { withServiceSpan } from '@src/utils/sentry.metrics';
 
@@ -23,6 +24,7 @@ interface ICreateEventParams {
   link?: string;
   venue?: string;
   description: string;
+  visibility?: string;
   groupIds?: string[];
   agentIds?: string[];
   tenantId: string;
@@ -42,11 +44,19 @@ interface IUpdateEventParams {
   link?: string;
   venue?: string;
   description?: string;
+  visibility?: string;
   groupIds?: string[];
   agentIds?: string[];
   tenantId: string;
   role: string;
   userId: string;
+  token: string;
+}
+
+interface IDeleteEventParams {
+  eventId: string;
+  userId: string;
+  role: string;
   token: string;
 }
 
@@ -113,6 +123,7 @@ class EventService {
           tenant_id: params.tenantId,
           created_by: params.createdBy,
           created_by_role: params.createdByRole,
+          visibility: params.visibility,
         },
         params.token,
       );
@@ -218,6 +229,7 @@ class EventService {
         updateData.description = params.description;
       if (params.status !== undefined) updateData.status = params.status;
       if (params.type !== undefined) updateData.type = params.type;
+      if (params.visibility !== undefined) updateData.visibility = params.visibility;
 
       if (params.startDate !== undefined) updateData.start_date = params.startDate;
       if (params.endDate !== undefined) updateData.end_date = params.endDate;
@@ -300,6 +312,56 @@ class EventService {
       return await eventRepository.findById(eventId, token);
     } catch (error) {
       return handleServiceError('EventService.getEventById', error);
+    }
+  }
+
+  async deleteEvent(params: IDeleteEventParams): Promise<void> {
+    try {
+      const event = await eventRepository.findById(params.eventId, params.token);
+
+      if (!event) {
+        throw new EventNotFoundError();
+      }
+
+      if (params.role !== 'admin' && event.created_by !== params.userId) {
+        throw new ForbiddenEventAccessError();
+      }
+
+      await eventRepository.deleteEvent(params.eventId, params.token);
+    } catch (error) {
+      if (error instanceof EventNotFoundError || error instanceof ForbiddenEventAccessError) {
+        throw error;
+      }
+      return handleServiceError('EventService.deleteEvent', error);
+    }
+  }
+
+  async getPublicEventById(eventId: string): Promise<IPublicEvent | null> {
+    try {
+      const raw = await eventRepository.findPublicEventById(eventId);
+
+      if (!raw) {
+        return null;
+      }
+
+      if (raw.status === 'cancelled' || raw.visibility !== 'public') {
+        return null;
+      }
+
+      return {
+        id: raw.id,
+        event_title: raw.event_title,
+        description: raw.description,
+        start_date: raw.start_date,
+        end_date: raw.end_date,
+        type: raw.type,
+        venue: raw.venue,
+        meeting_link: raw.meeting_link,
+        created_by_name: raw.created_by_name,
+        status: raw.status,
+      };
+    } catch (error) {
+      return handleServiceError('EventService.getPublicEventById', error);
     }
   }
 }

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -341,6 +341,7 @@ export type Database = {
           type: string
           updated_at: string
           venue: string | null
+          visibility: string
         }
         Insert: {
           created_at?: string
@@ -357,6 +358,7 @@ export type Database = {
           type: string
           updated_at?: string
           venue?: string | null
+          visibility?: string
         }
         Update: {
           created_at?: string
@@ -373,6 +375,7 @@ export type Database = {
           type?: string
           updated_at?: string
           venue?: string | null
+          visibility?: string
         }
         Relationships: [
           {

--- a/src/types/event.types.ts
+++ b/src/types/event.types.ts
@@ -26,7 +26,21 @@ export type IEvent = Pick<
   | 'created_by_role'
   | 'created_at'
   | 'updated_at'
+  | 'visibility'
 > & {
   groupIds: string[];
   agentIds: string[];
 };
+
+export interface IPublicEvent {
+  id: string;
+  event_title: string;
+  description: string | null;
+  start_date: string;
+  end_date: string | null;
+  type: string;
+  venue: string | null;
+  meeting_link: string | null;
+  created_by_name: string;
+  status: string;
+}

--- a/supabase/migrations/20260504154559_add_event_visibility_and_allow_agent_insert.sql
+++ b/supabase/migrations/20260504154559_add_event_visibility_and_allow_agent_insert.sql
@@ -1,0 +1,19 @@
+-- Add visibility column
+ALTER TABLE events
+  ADD COLUMN visibility TEXT NOT NULL DEFAULT 'private'
+  CHECK (visibility IN ('public', 'private'));
+
+-- Partial index for public lookups
+CREATE INDEX idx_events_visibility_public
+  ON events(visibility) WHERE visibility = 'public';
+
+-- Widen events_insert to include 'agent'
+-- Pattern: always DROP + CREATE (no ALTER POLICY used anywhere in this repo)
+DROP POLICY IF EXISTS "events_insert" ON events;
+
+CREATE POLICY "events_insert" ON events
+FOR INSERT WITH CHECK (
+  (auth.jwt() ->> 'app_role') IN ('admin', 'master_trainer', 'trainer', 'group_leader', 'agent')
+  AND tenant_id = (auth.jwt() ->> 'tenant_id')::UUID
+  AND created_by = (auth.jwt() ->> 'user_id')::UUID
+);

--- a/supabase/migrations/20260504163804_fix_events_read_allow_creator_access.sql
+++ b/supabase/migrations/20260504163804_fix_events_read_allow_creator_access.sql
@@ -1,0 +1,42 @@
+-- Allow creators (agent, group_leader) to read their own events immediately after insert,
+-- before event_agents/event_groups rows are populated.
+DROP POLICY IF EXISTS "events_read" ON events;
+
+CREATE POLICY "events_read" ON events
+FOR SELECT USING (
+  CASE (auth.jwt() ->> 'app_role')
+    WHEN 'admin' THEN
+      tenant_id = (auth.jwt() ->> 'tenant_id')::UUID
+
+    WHEN 'master_trainer' THEN
+      tenant_id = (auth.jwt() ->> 'tenant_id')::UUID
+
+    WHEN 'trainer' THEN
+      id IN (
+        SELECT event_id FROM event_groups
+        WHERE group_id IN (
+          SELECT group_id FROM group_trainers
+          WHERE trainer_id = (auth.jwt() ->> 'user_id')::UUID
+        )
+      )
+      AND tenant_id = (auth.jwt() ->> 'tenant_id')::UUID
+
+    ELSE (
+      tenant_id = (auth.jwt() ->> 'tenant_id')::UUID
+      AND (
+        created_by = (auth.jwt() ->> 'user_id')::UUID
+        OR id IN (
+          SELECT event_id FROM event_groups
+          WHERE group_id = (
+            SELECT group_id FROM users
+            WHERE id = (auth.jwt() ->> 'user_id')::UUID
+          )
+        )
+        OR id IN (
+          SELECT event_id FROM event_agents
+          WHERE user_id = (auth.jwt() ->> 'user_id')::UUID
+        )
+      )
+    )
+  END
+);

--- a/tests/integration/events.test.ts
+++ b/tests/integration/events.test.ts
@@ -384,22 +384,25 @@ describe('POST /api/events — happy path', () => {
 });
 
 describe('POST /api/events — role guard', () => {
-  it('returns 403 when called by agent role', async () => {
+  it('returns 201 when called by agent role (agent is now allowed to create own events)', async () => {
     expect(agentToken).not.toBeNull();
 
     const res = await request(app)
       .post('/api/events')
       .set('Authorization', `Bearer ${agentToken}`)
       .send({
-        title: 'Agent Event Attempt',
+        title: 'Agent Role Guard Event',
         startDate: futureDate(7),
         endDate: futureDateEnd(7),
         type: 'Face to Face',
-        description: 'Should be rejected',
-        groupIds: [GROUP_ID_ALPHA],
+        description: 'Agent is now in ALLOWED_ROLES',
       });
 
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(201);
+
+    if (res.body?.data?.id) {
+      createdEventIds.push(res.body.data.id as string);
+    }
   });
 
   it('returns 401 when no Authorization header is provided', async () => {
@@ -492,7 +495,7 @@ describe('POST /api/events — validation', () => {
     expect(res.body).toHaveProperty('message', 'Validation failed');
   });
 
-  it('returns 400 when both groupIds and agentIds are omitted', async () => {
+  it('returns 400 when both groupIds and agentIds are omitted (non-agent role)', async () => {
     expect(adminToken).not.toBeNull();
 
     const res = await request(app)
@@ -503,11 +506,11 @@ describe('POST /api/events — validation', () => {
         startDate: futureDate(7),
         endDate: futureDateEnd(7),
         type: 'Face to Face',
-        description: 'Should fail — at least one of groupIds or agentIds required',
+        description: 'Should fail — at least one of groupIds or agentIds required for admin',
       });
 
+    // The Zod schema no longer enforces this — the controller returns 400 with its own message
     expect(res.status).toBe(400);
-    expect(res.body).toHaveProperty('message', 'Validation failed');
   });
 
   it('returns 400 when groupIds is an empty array', async () => {
@@ -838,7 +841,7 @@ describe('PUT /api/events/:eventId — not found', () => {
 });
 
 describe('PUT /api/events/:eventId — role guard', () => {
-  it('returns 403 when called by agent role', async () => {
+  it('returns 404 when agent tries to update a non-existent event (agent is now allowed)', async () => {
     expect(agentToken).not.toBeNull();
 
     const res = await request(app)
@@ -846,7 +849,8 @@ describe('PUT /api/events/:eventId — role guard', () => {
       .set('Authorization', `Bearer ${agentToken}`)
       .send({ title: 'Agent Update Attempt' });
 
-    expect(res.status).toBe(403);
+    // Agent is now in ALLOWED_ROLES — event does not exist so 404 is expected
+    expect(res.status).toBe(404);
   });
 
   it('returns 401 when no Authorization header is provided', async () => {
@@ -1136,5 +1140,442 @@ describe('GET /api/events/:eventId — auth guard', () => {
       '/api/events/00000000-0000-0000-0000-000000000000',
     );
     expect(res.status).toBe(401);
+  });
+});
+
+/******************************************************************************
+  DELETE /api/events/:eventId
+******************************************************************************/
+
+describe('DELETE /api/events/:eventId', () => {
+  /** IDs created within this describe block — may already be deleted by test */
+  const deleteBlockEventIds: string[] = [];
+
+  afterAll(async () => {
+    for (const eventId of deleteBlockEventIds) {
+      try {
+        await supabaseService.adminDelete('events', { id: eventId });
+      } catch { /* best-effort — may already be deleted */ }
+    }
+  });
+
+  it('returns 204 and event is gone (404) after agent deletes their own event', async () => {
+    expect(agentToken).not.toBeNull();
+    expect(agentUserId).not.toBeNull();
+
+    // Create an event as the agent
+    const createRes = await request(app)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${agentToken}`)
+      .send({
+        title: 'Agent Event To Delete',
+        startDate: futureDate(3),
+        endDate: futureDateEnd(3),
+        type: 'Online',
+        description: 'This event will be deleted by the agent',
+      });
+
+    expect(createRes.status).toBe(201);
+    const eventId = createRes.body.data.id as string;
+    deleteBlockEventIds.push(eventId);
+
+    // Delete the event as the same agent
+    const deleteRes = await request(app)
+      .delete(`/api/events/${eventId}`)
+      .set('Authorization', `Bearer ${agentToken}`);
+
+    expect(deleteRes.status).toBe(204);
+
+    // Follow-up GET as same agent should return 404
+    const getRes = await request(app)
+      .get(`/api/events/${eventId}`)
+      .set('Authorization', `Bearer ${agentToken}`);
+
+    expect(getRes.status).toBe(404);
+  });
+
+  it('returns 403 or 404 when agent tries to delete another user\'s event', async () => {
+    expect(adminToken).not.toBeNull();
+    expect(agentToken).not.toBeNull();
+
+    // Create an event as admin
+    const createRes = await request(app)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        title: 'Admin Event Agent Cannot Delete',
+        startDate: futureDate(3),
+        endDate: futureDateEnd(3),
+        type: 'Face to Face',
+        description: 'Created by admin, agent should not be able to delete',
+        groupIds: [GROUP_ID_ALPHA],
+      });
+
+    expect(createRes.status).toBe(201);
+    const eventId = createRes.body.data.id as string;
+    deleteBlockEventIds.push(eventId);
+    createdEventIds.push(eventId);
+
+    // Agent attempts to delete an event they did not create
+    const deleteRes = await request(app)
+      .delete(`/api/events/${eventId}`)
+      .set('Authorization', `Bearer ${agentToken}`);
+
+    expect([403, 404]).toContain(deleteRes.status);
+  });
+
+  it('returns 401 when no Authorization header is provided', async () => {
+    const res = await request(app)
+      .delete('/api/events/00000000-0000-0000-0000-000000000001');
+
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for a non-existent event UUID', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const res = await request(app)
+      .delete('/api/events/00000000-0000-0000-0000-000000000000')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+/******************************************************************************
+  Agent event create + GET /api/events/:eventId/public
+******************************************************************************/
+
+describe('POST /api/events — agent create', () => {
+  it('returns 201 with agentIds:[self], groupIds:[], created_by_role:agent, visibility:public when no audience fields sent', async () => {
+    expect(agentToken).not.toBeNull();
+    expect(agentUserId).not.toBeNull();
+
+    const res = await request(app)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${agentToken}`)
+      .send({
+        title: 'Agent Personal Event',
+        startDate: futureDate(5),
+        endDate: futureDateEnd(5),
+        type: 'Online',
+        description: 'Created by agent with no audience override',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('success', true);
+
+    const event = res.body.data as Record<string, unknown>;
+    expect(event).toHaveProperty('id');
+    expect(event).toHaveProperty('created_by_role', 'agent');
+    expect(event).toHaveProperty('visibility', 'public');
+    expect(Array.isArray(event.agentIds)).toBe(true);
+    expect(event.agentIds).toContain(agentUserId!);
+    expect(Array.isArray(event.groupIds)).toBe(true);
+    expect((event.groupIds as string[]).length).toBe(0);
+
+    if (event.id) {
+      createdEventIds.push(event.id as string);
+    }
+  });
+
+  it('returns 201 with visibility:private when agent explicitly sets visibility:private', async () => {
+    expect(agentToken).not.toBeNull();
+
+    const res = await request(app)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${agentToken}`)
+      .send({
+        title: 'Agent Private Event',
+        startDate: futureDate(5),
+        endDate: futureDateEnd(5),
+        type: 'Face to Face',
+        description: 'Agent-set private visibility',
+        visibility: 'private',
+      });
+
+    expect(res.status).toBe(201);
+
+    const event = res.body.data as Record<string, unknown>;
+    expect(event).toHaveProperty('visibility', 'private');
+
+    if (event.id) {
+      createdEventIds.push(event.id as string);
+    }
+  });
+
+  it('returns 201 and server overrides groupIds/agentIds to [self]/[] when agent sends them', async () => {
+    expect(agentToken).not.toBeNull();
+    expect(agentUserId).not.toBeNull();
+    expect(adminUserId).not.toBeNull();
+
+    const res = await request(app)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${agentToken}`)
+      .send({
+        title: 'Agent Override Audience Event',
+        startDate: futureDate(5),
+        endDate: futureDateEnd(5),
+        type: 'Online',
+        description: 'Server should override groupIds and agentIds',
+        groupIds: [GROUP_ID_ALPHA],
+        agentIds: [adminUserId!],
+      });
+
+    expect(res.status).toBe(201);
+
+    const event = res.body.data as Record<string, unknown>;
+    expect(event).toHaveProperty('visibility', 'public');
+    expect(Array.isArray(event.agentIds)).toBe(true);
+    expect(event.agentIds).toContain(agentUserId!);
+    expect(event.agentIds).not.toContain(adminUserId!);
+    expect(Array.isArray(event.groupIds)).toBe(true);
+    expect((event.groupIds as string[]).length).toBe(0);
+
+    if (event.id) {
+      createdEventIds.push(event.id as string);
+    }
+  });
+
+  it('returns 201 with visibility:private when admin creates event with no visibility', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const res = await request(app)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        title: 'Admin Event No Visibility',
+        startDate: futureDate(5),
+        endDate: futureDateEnd(5),
+        type: 'Face to Face',
+        description: 'Admin default visibility should be private',
+        groupIds: [GROUP_ID_ALPHA],
+      });
+
+    expect(res.status).toBe(201);
+
+    const event = res.body.data as Record<string, unknown>;
+    expect(event).toHaveProperty('visibility', 'private');
+
+    if (event.id) {
+      createdEventIds.push(event.id as string);
+    }
+  });
+});
+
+describe('GET /api/events/:eventId/public', () => {
+  /** IDs created within this describe block — cleaned up in afterAll via createdEventIds */
+  let publicEventId: string | null = null;
+  let privateEventId: string | null = null;
+  let cancelledPublicEventId: string | null = null;
+  let completedPublicEventId: string | null = null;
+  let adminPublicEventId: string | null = null;
+
+  beforeAll(async () => {
+    if (!adminToken || !adminUserId) return;
+
+    // Create a public upcoming event
+    const publicRes = await request(app)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        title: 'Public Upcoming Event',
+        startDate: futureDate(5),
+        endDate: futureDateEnd(5),
+        type: 'Online',
+        description: 'Visible publicly',
+        groupIds: [GROUP_ID_ALPHA],
+        visibility: 'public',
+      });
+    if (publicRes.status === 201 && publicRes.body?.data?.id) {
+      publicEventId = publicRes.body.data.id as string;
+      createdEventIds.push(publicEventId);
+    }
+
+    // Create a private event
+    const privateRes = await request(app)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        title: 'Private Event',
+        startDate: futureDate(5),
+        endDate: futureDateEnd(5),
+        type: 'Online',
+        description: 'Should not be visible publicly',
+        groupIds: [GROUP_ID_ALPHA],
+        visibility: 'private',
+      });
+    if (privateRes.status === 201 && privateRes.body?.data?.id) {
+      privateEventId = privateRes.body.data.id as string;
+      createdEventIds.push(privateEventId);
+    }
+
+    // Create a public event then update it to cancelled via admin insert
+    const cancelledInsert = await supabaseService.adminInsert('events', {
+      tenant_id: TENANT_ID,
+      event_title: 'Cancelled Public Event',
+      start_date: futureDate(5),
+      end_date: futureDateEnd(5),
+      type: 'Online',
+      description: 'Cancelled and public',
+      status: 'cancelled',
+      visibility: 'public',
+      created_by: adminUserId,
+      created_by_role: 'admin',
+    });
+    const cancelledRows = cancelledInsert.data as unknown as { id: string }[];
+    if (cancelledRows && cancelledRows.length > 0) {
+      cancelledPublicEventId = cancelledRows[0].id;
+      createdEventIds.push(cancelledPublicEventId);
+    }
+
+    // Create a public completed event via admin insert
+    const completedInsert = await supabaseService.adminInsert('events', {
+      tenant_id: TENANT_ID,
+      event_title: 'Completed Public Event',
+      start_date: futureDate(5),
+      end_date: futureDateEnd(5),
+      type: 'Online',
+      description: 'Completed and public',
+      status: 'completed',
+      visibility: 'public',
+      created_by: adminUserId,
+      created_by_role: 'admin',
+    });
+    const completedRows = completedInsert.data as unknown as { id: string }[];
+    if (completedRows && completedRows.length > 0) {
+      completedPublicEventId = completedRows[0].id;
+      createdEventIds.push(completedPublicEventId);
+    }
+
+    // Admin-created public event (same as publicEventId but explicit separate record)
+    const adminPubRes = await request(app)
+      .post('/api/events')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        title: 'Admin Created Public Event',
+        startDate: futureDate(6),
+        endDate: futureDateEnd(6),
+        type: 'Face to Face',
+        description: 'Admin role creates a public event',
+        groupIds: [GROUP_ID_ALPHA],
+        visibility: 'public',
+      });
+    if (adminPubRes.status === 201 && adminPubRes.body?.data?.id) {
+      adminPublicEventId = adminPubRes.body.data.id as string;
+      createdEventIds.push(adminPublicEventId);
+    }
+  }, 30000);
+
+  it('returns 200 with IPublicEvent shape for a public upcoming event', async () => {
+    expect(publicEventId).not.toBeNull();
+
+    const res = await request(app)
+      .get(`/api/events/${publicEventId}/public`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success', true);
+    expect(res.body).toHaveProperty('data');
+
+    const data = res.body.data as Record<string, unknown>;
+    // Required fields
+    expect(data).toHaveProperty('id', publicEventId);
+    expect(data).toHaveProperty('event_title');
+    expect(data).toHaveProperty('start_date');
+    expect(data).toHaveProperty('end_date');
+    expect(data).toHaveProperty('type');
+    expect(data).toHaveProperty('status');
+    expect(data).toHaveProperty('created_by_name');
+    // Optional nullable fields present
+    expect(Object.keys(data)).toContain('description');
+    expect(Object.keys(data)).toContain('venue');
+    expect(Object.keys(data)).toContain('meeting_link');
+
+    // Sensitive fields MUST NOT be present
+    expect(data).not.toHaveProperty('tenant_id');
+    expect(data).not.toHaveProperty('created_by');
+    expect(data).not.toHaveProperty('created_by_role');
+    expect(data).not.toHaveProperty('visibility');
+    expect(data).not.toHaveProperty('agentIds');
+    expect(data).not.toHaveProperty('groupIds');
+  });
+
+  it('returns 404 with { success: false, message: "Event not found" } for a private event', async () => {
+    expect(privateEventId).not.toBeNull();
+
+    const res = await request(app)
+      .get(`/api/events/${privateEventId}/public`);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('success', false);
+    expect(res.body).toHaveProperty('message', 'Event not found');
+  });
+
+  it('returns 404 for a public but cancelled event', async () => {
+    if (!cancelledPublicEventId) return;
+
+    const res = await request(app)
+      .get(`/api/events/${cancelledPublicEventId}/public`);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('success', false);
+    expect(res.body).toHaveProperty('message', 'Event not found');
+  });
+
+  it('returns 200 for a public completed event (completed events are viewable)', async () => {
+    if (!completedPublicEventId) return;
+
+    const res = await request(app)
+      .get(`/api/events/${completedPublicEventId}/public`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success', true);
+
+    const data = res.body.data as Record<string, unknown>;
+    expect(data).toHaveProperty('status', 'completed');
+  });
+
+  it('returns 200 with no Authorization header (unauthenticated access)', async () => {
+    expect(publicEventId).not.toBeNull();
+
+    const res = await request(app)
+      .get(`/api/events/${publicEventId}/public`);
+    // Deliberately no .set('Authorization', ...) header
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success', true);
+  });
+
+  it('returns 404 for a non-existent UUID', async () => {
+    const res = await request(app)
+      .get('/api/events/00000000-0000-0000-0000-000000000000/public');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('success', false);
+    expect(res.body).toHaveProperty('message', 'Event not found');
+  });
+
+  it('returns 404 for a garbage non-UUID string', async () => {
+    const res = await request(app)
+      .get('/api/events/not-a-valid-uuid/public');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('success', false);
+    expect(res.body).toHaveProperty('message', 'Event not found');
+  });
+
+  it('returns 200 for an admin-created public event (model is role-agnostic)', async () => {
+    expect(adminPublicEventId).not.toBeNull();
+
+    const res = await request(app)
+      .get(`/api/events/${adminPublicEventId}/public`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success', true);
+
+    const data = res.body.data as Record<string, unknown>;
+    expect(data).toHaveProperty('id', adminPublicEventId);
+    expect(data).not.toHaveProperty('tenant_id');
+    expect(data).not.toHaveProperty('visibility');
   });
 });


### PR DESCRIPTION
## Summary

- Agents can now create, update, and delete their own calendar events
- Server enforces `agentIds=[self]` and `groupIds=[]` for agent role; `visibility` defaults to `'public'` for agents, `'private'` for all other roles
- New `visibility` field (`'public' | 'private'`) added to events — optional on create/update, present on all event responses
- New `DELETE /api/events/:eventId` endpoint (hard delete, cascades to junction tables)
- New `GET /api/events/:eventId/public` endpoint — no auth required, filters by `visibility='public'` and `status != 'cancelled'`, omits internal fields

## DB changes

- `events.visibility TEXT NOT NULL DEFAULT 'private'` with partial index
- `events_insert` RLS widened to include `agent` role
- `events_read` RLS updated to allow creators to read their own event immediately after insert

## Test plan

- [ ] Agent creates event → `201`, response has `agentIds: [self]`, `groupIds: []`, `visibility: 'public'`
- [ ] Agent updates own event → `200`
- [ ] Agent deletes own event → `204`, follow-up GET → `404`
- [ ] Agent attempts to delete another user's event → `403`/`404`
- [ ] `GET /api/events/:id/public` with public upcoming event (no auth) → `200`, response omits internal fields
- [ ] `GET /api/events/:id/public` with private or cancelled event → `404`
- [ ] 52/52 integration tests passing