### PR TITLE
feat(agent-codes): PUT /api/agent-codes/:agentCode rename endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3531,6 +3531,145 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /agent-codes/{agentCode}:
+    put:
+      tags: [Agent Codes]
+      summary: Rename an agent code (admin only)
+      description: >
+        Renames an existing agent code within the caller's tenant. The caller
+        must supply a valid Bearer token belonging to a user with the `admin`
+        role; any other role returns 403. The tenant is derived from the JWT —
+        clients cannot specify it.
+
+
+        Only the `agent_code` column is updated. The `is_used`, `user_id`, and
+        `created_at` values are left unchanged. Renaming a code that is already
+        in use (`isUsed: true`) is permitted — the associated user's claim is
+        preserved under the new code value.
+
+
+        The path parameter `:agentCode` is the **current** value of the code to
+        rename (case-sensitive). URL-encode it if it contains characters that
+        are not safe in a URI path segment. Returns 404 if no code with that
+        value exists in the tenant. Returns 409 if the requested new value
+        already exists in the tenant.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: agentCode
+          in: path
+          required: true
+          schema:
+            type: string
+          description: >
+            The current agent code to rename (case-sensitive, URL-encoded if
+            necessary).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [agentCode]
+              properties:
+                agentCode:
+                  type: string
+                  minLength: 1
+                  description: >
+                    The new agent code value. Must be a non-empty string. Must
+                    not already exist in the tenant — a duplicate value returns
+                    409.
+                  example: T77811M
+            example:
+              agentCode: T77811M
+      responses:
+        '200':
+          description: Agent code renamed successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, data]
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/AgentCodeListItem'
+              example:
+                success: true
+                data:
+                  agentCode: T77811M
+                  isUsed: false
+                  userId: null
+                  createdAt: '2025-01-01T00:00:00.000Z'
+                  updatedAt: '2026-05-12T10:00:00.000Z'
+        '400':
+          description: >
+            Bad request. Returned when the request body fails Zod validation —
+            e.g. `agentCode` missing, empty string, or an unknown top-level
+            field is present.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                message: Validation failed
+                errors:
+                  - code: too_small
+                    minimum: 1
+                    type: string
+                    inclusive: true
+                    exact: false
+                    message: String must contain at least 1 character(s)
+                    path:
+                      - agentCode
+        '401':
+          description: >
+            Unauthorized. Returned when the `Authorization` header is absent,
+            malformed, or contains an invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Unauthorized
+        '403':
+          description: Forbidden. Returned when the authenticated user is not an admin.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Forbidden
+        '404':
+          description: >
+            Not found. Returned when no agent code matching the path parameter
+            exists in the caller's tenant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Agent code not found
+        '409':
+          description: >
+            Conflict. Returned when the requested new `agentCode` value already
+            exists in the caller's tenant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Agent code already exists
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   ##############################################################################
   # COACHING SESSIONS
   ##############################################################################

--- a/src/controllers/agentCode.controller.ts
+++ b/src/controllers/agentCode.controller.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Response } from 'express';
 import { z } from 'zod';
 
+import { AgentCodeConflictError, AgentCodeNotFoundError } from '@src/models/errors/agentCode.errors';
 import { RouteError } from '@src/models/errors/route.error';
 import { IBaseReq, IBaseRes } from '@src/models/interfaces/base.interface';
 import agentCodeService from '@src/services/agentCode.service';
@@ -41,6 +42,11 @@ export interface IAgentCodeListItem {
 export interface IListAgentCodesRes extends IBaseRes {
   success: boolean;
   data: IAgentCodeListItem[];
+}
+
+export interface IUpdateAgentCodeRes extends IBaseRes {
+  success: boolean;
+  data: IAgentCodeListItem;
 }
 
 const listAgentCodesQuerySchema = z.object({
@@ -134,6 +140,53 @@ class AgentCodeController {
       res.status(HttpStatusCodes.OK).json(responseBody);
     } catch (error) {
       return handleControllerError('AgentCodeController.list', error, next);
+    }
+  }
+
+  async update(
+    req: IBaseReq,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      if (req.user!.role !== 'admin') {
+        next(new RouteError(HttpStatusCodes.FORBIDDEN, 'Forbidden'));
+        return;
+      }
+
+      const token = req.headers['authorization']!.slice(7);
+      const currentAgentCode = req.params['agentCode'] as string;
+      const { agentCode: newAgentCode } = req.body;
+
+      const updated = await agentCodeService.update({
+        currentAgentCode,
+        newAgentCode,
+        tenantId: req.user!.tenant_id,
+        token,
+      });
+
+      const responseBody: IUpdateAgentCodeRes = {
+        success: true,
+        data: {
+          agentCode: updated.agent_code,
+          isUsed: updated.is_used,
+          userId: updated.user_id,
+          createdAt: updated.created_at,
+          updatedAt: updated.updated_at,
+        },
+      };
+
+      res.status(HttpStatusCodes.OK).json(responseBody);
+    } catch (error) {
+      if (error instanceof AgentCodeNotFoundError) {
+        next(new RouteError(HttpStatusCodes.NOT_FOUND, error.message));
+        return;
+      }
+      if (error instanceof AgentCodeConflictError) {
+        next(new RouteError(HttpStatusCodes.CONFLICT, error.message));
+        return;
+      }
+      return handleControllerError('AgentCodeController.update', error, next);
     }
   }
 }

--- a/src/models/errors/agentCode.errors.ts
+++ b/src/models/errors/agentCode.errors.ts
@@ -1,0 +1,13 @@
+export class AgentCodeNotFoundError extends Error {
+  constructor(message = 'Agent code not found') {
+    super(message);
+    this.name = 'AgentCodeNotFoundError';
+  }
+}
+
+export class AgentCodeConflictError extends Error {
+  constructor(message = 'Agent code already exists') {
+    super(message);
+    this.name = 'AgentCodeConflictError';
+  }
+}

--- a/src/repositories/agentCode.repository.ts
+++ b/src/repositories/agentCode.repository.ts
@@ -1,3 +1,4 @@
+import { AgentCodeConflictError, AgentCodeNotFoundError } from '@src/models/errors/agentCode.errors';
 import supabaseService from '@src/services/supabase.service';
 import { IAgentCode } from '@src/types/agentCode';
 import { Database } from '@src/types/database.types';
@@ -5,6 +6,9 @@ import { handleRepositoryError } from '@src/utils/errorHandlers';
 
 type AgentCodesRow = Database['public']['Tables']['agent_codes']['Row'];
 type AgentCodesInsert = Database['public']['Tables']['agent_codes']['Insert'];
+type AgentCodesUpdate = Database['public']['Tables']['agent_codes']['Update'];
+
+const UNIQUE_VIOLATION_CODE = '23505';
 
 /******************************************************************************
                             AgentCodeRepository
@@ -68,6 +72,37 @@ class AgentCodeRepository {
       return data.map((row) => this.mapRowToAgentCode(row));
     } catch (error) {
       return handleRepositoryError('AgentCodeRepository.upsertMany', error);
+    }
+  }
+
+  async update(
+    userToken: string,
+    filters: { tenant_id: string; agent_code: string },
+    values: AgentCodesUpdate,
+  ): Promise<IAgentCode> {
+    try {
+      const response = await supabaseService.userUpdate(
+        userToken,
+        'agent_codes',
+        values,
+        filters,
+      );
+
+      if (response.error) {
+        if ((response.error as { code?: string }).code === UNIQUE_VIOLATION_CODE) {
+          throw new AgentCodeConflictError();
+        }
+        throw new Error(response.error.message);
+      }
+
+      const rows = (response.data ?? []) as unknown as AgentCodesRow[];
+      if (rows.length === 0) {
+        throw new AgentCodeNotFoundError();
+      }
+
+      return this.mapRowToAgentCode(rows[0]);
+    } catch (error) {
+      return handleRepositoryError('AgentCodeRepository.update', error);
     }
   }
 }

--- a/src/routes/agentCode.routes.ts
+++ b/src/routes/agentCode.routes.ts
@@ -18,6 +18,12 @@ export const createAgentCodesSchema = z
   })
   .strict();
 
+export const updateAgentCodeSchema = z
+  .object({
+    agentCode: z.string().min(1),
+  })
+  .strict();
+
 /******************************************************************************
                             Router
 ******************************************************************************/
@@ -26,6 +32,14 @@ const router = express.Router();
 
 router.get('/', authenticate, (req, res, next) =>
   agentCodeController.list(req as unknown as IBaseReq, res, next),
+);
+
+router.put(
+  '/:agentCode',
+  authenticate,
+  validate(updateAgentCodeSchema),
+  (req, res, next) =>
+    agentCodeController.update(req as unknown as IBaseReq, res, next),
 );
 
 router.post(

--- a/src/services/agentCode.service.ts
+++ b/src/services/agentCode.service.ts
@@ -1,6 +1,8 @@
 import agentCodeRepository from '@src/repositories/agentCode.repository';
+import { AgentCodeConflictError, AgentCodeNotFoundError } from '@src/models/errors/agentCode.errors';
 import { IAgentCode } from '@src/types/agentCode';
 import { handleServiceError } from '@src/utils/errorHandlers';
+import { getRootCause } from '@src/utils/sentry.utils';
 
 /******************************************************************************
                             Interfaces
@@ -14,6 +16,13 @@ interface ICreateManyParams {
 
 interface IListParams {
   isUsed?: boolean;
+  token: string;
+}
+
+interface IUpdateParams {
+  currentAgentCode: string;
+  newAgentCode: string;
+  tenantId: string;
   token: string;
 }
 
@@ -49,6 +58,28 @@ class AgentCodeService {
       );
     } catch (error) {
       return handleServiceError('AgentCodeService.list', error);
+    }
+  }
+
+  async update(params: IUpdateParams): Promise<IAgentCode> {
+    try {
+      return await agentCodeRepository.update(
+        params.token,
+        { tenant_id: params.tenantId, agent_code: params.currentAgentCode },
+        {
+          agent_code: params.newAgentCode,
+          updated_at: new Date().toISOString(),
+        },
+      );
+    } catch (error) {
+      const rootCause = getRootCause(error);
+      if (
+        rootCause instanceof AgentCodeNotFoundError ||
+        rootCause instanceof AgentCodeConflictError
+      ) {
+        throw rootCause;
+      }
+      return handleServiceError('AgentCodeService.update', error);
     }
   }
 }

--- a/tests/unit/agentCodes/agentCode.controller.test.ts
+++ b/tests/unit/agentCodes/agentCode.controller.test.ts
@@ -36,6 +36,7 @@ import type { ICreateAgentCodesReq } from '@src/controllers/agentCode.controller
 import { agentCodeService } from '@src/services/agentCode.service';
 import { RouteError } from '@src/models/errors/route.error';
 import { ControllerError } from '@src/models/errors/layer.errors';
+import { AgentCodeNotFoundError, AgentCodeConflictError } from '@src/models/errors/agentCode.errors';
 import type { IAgentCode } from '@src/types/agentCode';
 import type { IBaseReq } from '@src/models/interfaces/base.interface';
 
@@ -350,6 +351,149 @@ describe('AgentCodeController.list', () => {
     const next = makeNext();
 
     await agentCodeController.list(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0][0];
+    expect(err).toBeInstanceOf(ControllerError);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});
+
+/******************************************************************************
+  Test suite — AgentCodeController.update
+******************************************************************************/
+
+const mockUpdatedAgentCode: IAgentCode = {
+  agent_code: 'NEW001',
+  is_used: true,
+  user_id: 'user-uuid-111',
+  created_at: '2026-05-01T12:00:00.000Z',
+  updated_at: '2026-05-12T08:00:00.000Z',
+};
+
+function makeUpdateReq(overrides: Partial<IBaseReq> = {}): IBaseReq {
+  return {
+    headers: { authorization: `Bearer ${USER_TOKEN}` },
+    params: { agentCode: 'OLD001' },
+    body: { agentCode: 'NEW001' },
+    user: { id: ADMIN_ID, tenant_id: TENANT_ID, role: 'admin' },
+    ...overrides,
+  } as unknown as IBaseReq;
+}
+
+describe('AgentCodeController.update', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('returns 403 when role is not admin', async () => {
+    const req = makeUpdateReq({
+      user: { id: ADMIN_ID, tenant_id: TENANT_ID, role: 'agent' },
+    } as Partial<IBaseReq>);
+    const res = makeRes();
+    const next = makeNext();
+
+    await agentCodeController.update(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0][0];
+    expect(err).toBeInstanceOf(RouteError);
+    expect((err as RouteError).status).toBe(403);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('calls agentCodeService.update with correct params from req', async () => {
+    const spy = jest
+      .spyOn(agentCodeService, 'update')
+      .mockResolvedValue(mockUpdatedAgentCode);
+
+    const req = makeUpdateReq();
+    const res = makeRes();
+    const next = makeNext();
+
+    await agentCodeController.update(req, res, next as NextFunction);
+
+    expect(spy).toHaveBeenCalledWith({
+      currentAgentCode: 'OLD001',
+      newAgentCode: 'NEW001',
+      tenantId: TENANT_ID,
+      token: USER_TOKEN,
+    });
+  });
+
+  it('returns 200 with { success: true, data: { agentCode, isUsed, userId, createdAt, updatedAt } } on success', async () => {
+    jest
+      .spyOn(agentCodeService, 'update')
+      .mockResolvedValue(mockUpdatedAgentCode);
+
+    const req = makeUpdateReq();
+    const res = makeRes();
+    const next = makeNext();
+
+    await agentCodeController.update(req, res, next as NextFunction);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        agentCode: 'NEW001',
+        isUsed: true,
+        userId: 'user-uuid-111',
+        createdAt: '2026-05-01T12:00:00.000Z',
+        updatedAt: '2026-05-12T08:00:00.000Z',
+      },
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next(RouteError) with status 404 when service throws AgentCodeNotFoundError', async () => {
+    jest
+      .spyOn(agentCodeService, 'update')
+      .mockRejectedValue(new AgentCodeNotFoundError());
+
+    const req = makeUpdateReq();
+    const res = makeRes();
+    const next = makeNext();
+
+    await agentCodeController.update(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0][0];
+    expect(err).toBeInstanceOf(RouteError);
+    expect((err as RouteError).status).toBe(404);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('calls next(RouteError) with status 409 when service throws AgentCodeConflictError', async () => {
+    jest
+      .spyOn(agentCodeService, 'update')
+      .mockRejectedValue(new AgentCodeConflictError());
+
+    const req = makeUpdateReq();
+    const res = makeRes();
+    const next = makeNext();
+
+    await agentCodeController.update(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0][0];
+    expect(err).toBeInstanceOf(RouteError);
+    expect((err as RouteError).status).toBe(409);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('calls next(ControllerError) for unexpected service errors', async () => {
+    jest
+      .spyOn(agentCodeService, 'update')
+      .mockRejectedValue(new Error('unexpected failure'));
+
+    const req = makeUpdateReq();
+    const res = makeRes();
+    const next = makeNext();
+
+    await agentCodeController.update(req, res, next as NextFunction);
 
     expect(next).toHaveBeenCalledTimes(1);
     const err = next.mock.calls[0][0];

--- a/tests/unit/agentCodes/agentCode.repository.test.ts
+++ b/tests/unit/agentCodes/agentCode.repository.test.ts
@@ -31,16 +31,19 @@ jest.mock('@src/services/supabase.service', () => ({
   default: {
     userUpsert: jest.fn(),
     userSelect: jest.fn(),
+    userUpdate: jest.fn(),
   },
   supabaseService: {
     userUpsert: jest.fn(),
     userSelect: jest.fn(),
+    userUpdate: jest.fn(),
   },
 }));
 
 import { agentCodeRepository } from '@src/repositories/agentCode.repository';
 import supabaseService from '@src/services/supabase.service';
 import { RepositoryError } from '@src/models/errors/layer.errors';
+import { AgentCodeNotFoundError, AgentCodeConflictError } from '@src/models/errors/agentCode.errors';
 
 /******************************************************************************
   Fixtures
@@ -284,6 +287,122 @@ describe('AgentCodeRepository.findAll', () => {
 
     await expect(
       agentCodeRepository.findAll(USER_TOKEN),
+    ).rejects.toBeInstanceOf(RepositoryError);
+  });
+});
+
+/******************************************************************************
+  Test suite — AgentCodeRepository.update
+******************************************************************************/
+
+const mockUpdateRow = {
+  id: 'uuid-1',
+  tenant_id: TENANT_ID,
+  agent_code: 'NEW001',
+  user_id: 'user-uuid-111',
+  is_used: true,
+  created_at: '2026-05-01T12:00:00.000Z',
+  updated_at: '2026-05-12T08:00:00.000Z',
+};
+
+describe('AgentCodeRepository.update', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('calls supabaseService.userUpdate with correct table, values, and filters', async () => {
+    jest.spyOn(supabaseService, 'userUpdate').mockResolvedValue({
+      data: [mockUpdateRow],
+      error: null,
+    } as any);
+
+    await agentCodeRepository.update(
+      USER_TOKEN,
+      { tenant_id: TENANT_ID, agent_code: 'OLD001' },
+      { agent_code: 'NEW001', updated_at: '2026-05-12T08:00:00.000Z' },
+    );
+
+    expect(supabaseService.userUpdate).toHaveBeenCalledWith(
+      USER_TOKEN,
+      'agent_codes',
+      { agent_code: 'NEW001', updated_at: '2026-05-12T08:00:00.000Z' },
+      { tenant_id: TENANT_ID, agent_code: 'OLD001' },
+    );
+  });
+
+  it('maps the returned row to IAgentCode including user_id', async () => {
+    jest.spyOn(supabaseService, 'userUpdate').mockResolvedValue({
+      data: [mockUpdateRow],
+      error: null,
+    } as any);
+
+    const result = await agentCodeRepository.update(
+      USER_TOKEN,
+      { tenant_id: TENANT_ID, agent_code: 'OLD001' },
+      { agent_code: 'NEW001', updated_at: '2026-05-12T08:00:00.000Z' },
+    );
+
+    expect(result).toEqual({
+      agent_code: 'NEW001',
+      is_used: true,
+      user_id: 'user-uuid-111',
+      created_at: '2026-05-01T12:00:00.000Z',
+      updated_at: '2026-05-12T08:00:00.000Z',
+    });
+  });
+
+  it('throws RepositoryError wrapping AgentCodeNotFoundError when response.data is an empty array', async () => {
+    jest.spyOn(supabaseService, 'userUpdate').mockResolvedValue({
+      data: [],
+      error: null,
+    } as any);
+
+    let thrown: unknown;
+    try {
+      await agentCodeRepository.update(
+        USER_TOKEN,
+        { tenant_id: TENANT_ID, agent_code: 'MISSING' },
+        { agent_code: 'NEW001', updated_at: '2026-05-12T08:00:00.000Z' },
+      );
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(RepositoryError);
+    expect((thrown as RepositoryError).cause).toBeInstanceOf(AgentCodeNotFoundError);
+  });
+
+  it('throws RepositoryError wrapping AgentCodeConflictError when response.error.code is 23505', async () => {
+    jest.spyOn(supabaseService, 'userUpdate').mockResolvedValue({
+      data: null,
+      error: { code: '23505', message: 'duplicate key value violates unique constraint' },
+    } as any);
+
+    let thrown: unknown;
+    try {
+      await agentCodeRepository.update(
+        USER_TOKEN,
+        { tenant_id: TENANT_ID, agent_code: 'OLD001' },
+        { agent_code: 'DUPLICATE', updated_at: '2026-05-12T08:00:00.000Z' },
+      );
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(RepositoryError);
+    expect((thrown as RepositoryError).cause).toBeInstanceOf(AgentCodeConflictError);
+  });
+
+  it('throws RepositoryError when response.error has a non-23505 code', async () => {
+    jest.spyOn(supabaseService, 'userUpdate').mockResolvedValue({
+      data: null,
+      error: { code: '42501', message: 'permission denied for table agent_codes' },
+    } as any);
+
+    await expect(
+      agentCodeRepository.update(
+        USER_TOKEN,
+        { tenant_id: TENANT_ID, agent_code: 'OLD001' },
+        { agent_code: 'NEW001', updated_at: '2026-05-12T08:00:00.000Z' },
+      ),
     ).rejects.toBeInstanceOf(RepositoryError);
   });
 });

--- a/tests/unit/agentCodes/agentCode.service.test.ts
+++ b/tests/unit/agentCodes/agentCode.service.test.ts
@@ -26,7 +26,8 @@ jest.mock('@src/services/supabase.service', () => ({
 
 import { agentCodeService } from '@src/services/agentCode.service';
 import { agentCodeRepository } from '@src/repositories/agentCode.repository';
-import { ServiceError } from '@src/models/errors/layer.errors';
+import { ServiceError, RepositoryError } from '@src/models/errors/layer.errors';
+import { AgentCodeNotFoundError, AgentCodeConflictError } from '@src/models/errors/agentCode.errors';
 import type { IAgentCode } from '@src/types/agentCode';
 
 /******************************************************************************
@@ -160,5 +161,106 @@ describe('AgentCodeService.list', () => {
     await expect(
       agentCodeService.list({ token: USER_TOKEN }),
     ).rejects.toThrow(ServiceError);
+  });
+});
+
+/******************************************************************************
+  Test suite — AgentCodeService.update
+******************************************************************************/
+
+const mockUpdatedAgentCode: IAgentCode = {
+  agent_code: 'NEW001',
+  is_used: true,
+  user_id: 'user-uuid-111',
+  created_at: '2026-05-01T12:00:00.000Z',
+  updated_at: '2026-05-12T08:00:00.000Z',
+};
+
+describe('AgentCodeService.update', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('calls agentCodeRepository.update with correct token, filters, and values including updated_at', async () => {
+    const spy = jest
+      .spyOn(agentCodeRepository, 'update')
+      .mockResolvedValue(mockUpdatedAgentCode);
+
+    await agentCodeService.update({
+      currentAgentCode: 'OLD001',
+      newAgentCode: 'NEW001',
+      tenantId: TENANT_ID,
+      token: USER_TOKEN,
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      USER_TOKEN,
+      { tenant_id: TENANT_ID, agent_code: 'OLD001' },
+      expect.objectContaining({ agent_code: 'NEW001', updated_at: expect.any(String) }),
+    );
+  });
+
+  it('returns the IAgentCode returned by the repository', async () => {
+    jest
+      .spyOn(agentCodeRepository, 'update')
+      .mockResolvedValue(mockUpdatedAgentCode);
+
+    const result = await agentCodeService.update({
+      currentAgentCode: 'OLD001',
+      newAgentCode: 'NEW001',
+      tenantId: TENANT_ID,
+      token: USER_TOKEN,
+    });
+
+    expect(result).toEqual(mockUpdatedAgentCode);
+  });
+
+  it('re-throws AgentCodeNotFoundError directly when it is the root cause', async () => {
+    const rootCause = new AgentCodeNotFoundError();
+    const wrappedError = new RepositoryError('Repository error', rootCause);
+
+    jest
+      .spyOn(agentCodeRepository, 'update')
+      .mockRejectedValue(wrappedError);
+
+    await expect(
+      agentCodeService.update({
+        currentAgentCode: 'MISSING',
+        newAgentCode: 'NEW001',
+        tenantId: TENANT_ID,
+        token: USER_TOKEN,
+      }),
+    ).rejects.toBeInstanceOf(AgentCodeNotFoundError);
+  });
+
+  it('re-throws AgentCodeConflictError directly when it is the root cause', async () => {
+    const rootCause = new AgentCodeConflictError();
+    const wrappedError = new RepositoryError('Repository error', rootCause);
+
+    jest
+      .spyOn(agentCodeRepository, 'update')
+      .mockRejectedValue(wrappedError);
+
+    await expect(
+      agentCodeService.update({
+        currentAgentCode: 'OLD001',
+        newAgentCode: 'DUPLICATE',
+        tenantId: TENANT_ID,
+        token: USER_TOKEN,
+      }),
+    ).rejects.toBeInstanceOf(AgentCodeConflictError);
+  });
+
+  it('wraps unexpected errors in ServiceError via handleServiceError', async () => {
+    jest
+      .spyOn(agentCodeRepository, 'update')
+      .mockRejectedValue(new Error('unexpected db failure'));
+
+    await expect(
+      agentCodeService.update({
+        currentAgentCode: 'OLD001',
+        newAgentCode: 'NEW001',
+        tenantId: TENANT_ID,
+        token: USER_TOKEN,
+      }),
+    ).rejects.toBeInstanceOf(ServiceError);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `PUT /api/agent-codes/:agentCode` — admin-only endpoint to rename an existing agent code in place
- URL param is the **current** code value; body `{ "agentCode": "T77811M" }` is the new value
- Only `agent_code` is mutated — `is_used`, `user_id`, `created_at` are untouched; renaming a used code is allowed
- 404 when the current code doesn't exist in the tenant; 409 when the new code already exists (unique constraint)
- Response: `{ success: true, data: AgentCodeListItem }` — full updated row, same shape as GET list items
- Domain errors (`AgentCodeNotFoundError`, `AgentCodeConflictError`) flow through the layered error chain via `getRootCause`

## Test plan

- [x] Unit tests: controller (admin gate, param/body forwarding, 200/404/409 mapping), service (domain error re-throw), repository (userUpdate call, empty-result 404, 23505 conflict 409) — 538 tests, all green
- [ ] Integration tests: run `npx jest tests/integration/agentCodes.test.ts` against seeded DB — 401/403/404/409/200 happy path, used-code rename
- [ ] Manual smoke:
  ```bash
  # happy path
  curl -X PUT "$BASE/api/agent-codes/T66701C" \
    -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
    -d '{"agentCode":"T77811M"}' | jq

  # 404
  curl -i -X PUT "$BASE/api/agent-codes/DOES-NOT-EXIST" \
    -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
    -d '{"agentCode":"T77812M"}'

  # 409
  curl -i -X PUT "$BASE/api/agent-codes/T77811M" \
    -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
    -d '{"agentCode":"T66702C"}'
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)