### PR TITLE
feat(agent-codes): add DELETE /agent-codes/:agentCode endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3669,6 +3669,90 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags: [Agent Codes]
+      summary: Delete an agent code
+      description: >
+        Deletes an existing agent code within the caller's tenant. The caller
+        must supply a valid Bearer token belonging to a user with the `admin`
+        role; any other role returns 403. The tenant is derived from the JWT —
+        clients cannot specify it.
+
+
+        The path parameter `:agentCode` is the **current** value of the code to
+        delete (case-sensitive). URL-encode it if it contains characters that
+        are not safe in a URI path segment. Returns 404 if no code with that
+        value exists in the tenant. Returns 409 if the code is currently in use
+        (`isUsed: true`) — in-use codes cannot be deleted.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: agentCode
+          in: path
+          required: true
+          schema:
+            type: string
+          description: >
+            The agent code to delete (case-sensitive, URL-encoded if
+            necessary).
+      responses:
+        '200':
+          description: Agent code deleted successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success]
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+              example:
+                success: true
+        '401':
+          description: >
+            Unauthorized. Returned when the `Authorization` header is absent,
+            malformed, or contains an invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Unauthorized
+        '403':
+          description: Forbidden. Returned when the authenticated user is not an admin.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Forbidden
+        '404':
+          description: >
+            Not found. Returned when no agent code matching the path parameter
+            exists in the caller's tenant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Agent code not found
+        '409':
+          description: >
+            Conflict. Returned when the agent code is currently in use
+            (`isUsed: true`) and cannot be deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Agent code is in use
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   ##############################################################################
   # COACHING SESSIONS

--- a/src/controllers/agentCode.controller.ts
+++ b/src/controllers/agentCode.controller.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Response } from 'express';
 import { z } from 'zod';
 
-import { AgentCodeConflictError, AgentCodeNotFoundError } from '@src/models/errors/agentCode.errors';
+import { AgentCodeConflictError, AgentCodeInUseError, AgentCodeNotFoundError } from '@src/models/errors/agentCode.errors';
 import { RouteError } from '@src/models/errors/route.error';
 import { IBaseReq, IBaseRes } from '@src/models/interfaces/base.interface';
 import agentCodeService from '@src/services/agentCode.service';
@@ -187,6 +187,29 @@ class AgentCodeController {
         return;
       }
       return handleControllerError('AgentCodeController.update', error, next);
+    }
+  }
+
+  async remove(req: IBaseReq, res: Response, next: NextFunction): Promise<void> {
+    try {
+      if (req.user!.role !== 'admin') {
+        next(new RouteError(HttpStatusCodes.FORBIDDEN, 'Forbidden'));
+        return;
+      }
+      const token = req.headers['authorization']!.slice(7);
+      const agentCode = req.params['agentCode'] as string;
+      await agentCodeService.remove({ agentCode, tenantId: req.user!.tenant_id, token });
+      res.status(HttpStatusCodes.OK).json({ success: true });
+    } catch (error) {
+      if (error instanceof AgentCodeNotFoundError) {
+        next(new RouteError(HttpStatusCodes.NOT_FOUND, error.message));
+        return;
+      }
+      if (error instanceof AgentCodeInUseError) {
+        next(new RouteError(HttpStatusCodes.CONFLICT, error.message));
+        return;
+      }
+      return handleControllerError('AgentCodeController.remove', error, next);
     }
   }
 }

--- a/src/models/errors/agentCode.errors.ts
+++ b/src/models/errors/agentCode.errors.ts
@@ -11,3 +11,10 @@ export class AgentCodeConflictError extends Error {
     this.name = 'AgentCodeConflictError';
   }
 }
+
+export class AgentCodeInUseError extends Error {
+  constructor(message = 'Agent code is in use') {
+    super(message);
+    this.name = 'AgentCodeInUseError';
+  }
+}

--- a/src/repositories/agentCode.repository.ts
+++ b/src/repositories/agentCode.repository.ts
@@ -1,4 +1,7 @@
-import { AgentCodeConflictError, AgentCodeNotFoundError } from '@src/models/errors/agentCode.errors';
+import {
+  AgentCodeConflictError,
+  AgentCodeNotFoundError,
+} from '@src/models/errors/agentCode.errors';
 import supabaseService from '@src/services/supabase.service';
 import { IAgentCode } from '@src/types/agentCode';
 import { Database } from '@src/types/database.types';
@@ -89,7 +92,9 @@ class AgentCodeRepository {
       );
 
       if (response.error) {
-        if ((response.error as { code?: string }).code === UNIQUE_VIOLATION_CODE) {
+        if (
+          (response.error as { code?: string }).code === UNIQUE_VIOLATION_CODE
+        ) {
           throw new AgentCodeConflictError();
         }
         throw new Error(response.error.message);
@@ -103,6 +108,63 @@ class AgentCodeRepository {
       return this.mapRowToAgentCode(rows[0]);
     } catch (error) {
       return handleRepositoryError('AgentCodeRepository.update', error);
+    }
+  }
+
+  async findByTenantAndCode(
+    userToken: string,
+    filters: { tenant_id: string; agent_code: string },
+  ): Promise<IAgentCode | null> {
+    try {
+      const response = await supabaseService.userSelect(
+        userToken,
+        'agent_codes',
+        '*',
+        filters,
+      );
+
+      if (response.error) {
+        throw new Error(response.error.message);
+      }
+
+      const rows = (response.data ?? []) as unknown as AgentCodesRow[];
+      if (rows.length === 0) {
+        return null;
+      }
+
+      return this.mapRowToAgentCode(rows[0]);
+    } catch (error) {
+      return handleRepositoryError(
+        'AgentCodeRepository.findByTenantAndCode',
+        error,
+      );
+    }
+  }
+
+  async deleteByAgentCode(
+    userToken: string,
+    filters: { tenant_id: string; agent_code: string },
+  ): Promise<void> {
+    try {
+      const response = await supabaseService.userDelete(
+        userToken,
+        'agent_codes',
+        filters,
+      );
+
+      if (response.error) {
+        throw new Error(response.error.message);
+      }
+
+      const rows = (response.data ?? []) as unknown as AgentCodesRow[];
+      if (rows.length === 0) {
+        throw new AgentCodeNotFoundError();
+      }
+    } catch (error) {
+      return handleRepositoryError(
+        'AgentCodeRepository.deleteByAgentCode',
+        error,
+      );
     }
   }
 }

--- a/src/routes/agentCode.routes.ts
+++ b/src/routes/agentCode.routes.ts
@@ -42,6 +42,10 @@ router.patch(
     agentCodeController.update(req as unknown as IBaseReq, res, next),
 );
 
+router.delete('/:agentCode', authenticate, (req, res, next) =>
+  agentCodeController.remove(req as unknown as IBaseReq, res, next),
+);
+
 router.post(
   '/',
   authenticate,

--- a/src/services/agentCode.service.ts
+++ b/src/services/agentCode.service.ts
@@ -1,5 +1,5 @@
 import agentCodeRepository from '@src/repositories/agentCode.repository';
-import { AgentCodeConflictError, AgentCodeNotFoundError } from '@src/models/errors/agentCode.errors';
+import { AgentCodeConflictError, AgentCodeInUseError, AgentCodeNotFoundError } from '@src/models/errors/agentCode.errors';
 import { IAgentCode } from '@src/types/agentCode';
 import { handleServiceError } from '@src/utils/errorHandlers';
 import { getRootCause } from '@src/utils/sentry.utils';
@@ -22,6 +22,12 @@ interface IListParams {
 interface IUpdateParams {
   currentAgentCode: string;
   newAgentCode: string;
+  tenantId: string;
+  token: string;
+}
+
+interface IDeleteParams {
+  agentCode: string;
   tenantId: string;
   token: string;
 }
@@ -80,6 +86,30 @@ class AgentCodeService {
         throw rootCause;
       }
       return handleServiceError('AgentCodeService.update', error);
+    }
+  }
+
+  async remove(params: IDeleteParams): Promise<void> {
+    try {
+      const existing = await agentCodeRepository.findByTenantAndCode(
+        params.token,
+        { tenant_id: params.tenantId, agent_code: params.agentCode },
+      );
+      if (!existing) throw new AgentCodeNotFoundError();
+      if (existing.is_used) throw new AgentCodeInUseError();
+      await agentCodeRepository.deleteByAgentCode(
+        params.token,
+        { tenant_id: params.tenantId, agent_code: params.agentCode },
+      );
+    } catch (error) {
+      const rootCause = getRootCause(error);
+      if (
+        rootCause instanceof AgentCodeNotFoundError ||
+        rootCause instanceof AgentCodeInUseError
+      ) {
+        throw rootCause;
+      }
+      return handleServiceError('AgentCodeService.remove', error);
     }
   }
 }

--- a/tests/unit/agentCodes/agentCode.controller.test.ts
+++ b/tests/unit/agentCodes/agentCode.controller.test.ts
@@ -36,7 +36,7 @@ import type { ICreateAgentCodesReq } from '@src/controllers/agentCode.controller
 import { agentCodeService } from '@src/services/agentCode.service';
 import { RouteError } from '@src/models/errors/route.error';
 import { ControllerError } from '@src/models/errors/layer.errors';
-import { AgentCodeNotFoundError, AgentCodeConflictError } from '@src/models/errors/agentCode.errors';
+import { AgentCodeNotFoundError, AgentCodeConflictError, AgentCodeInUseError } from '@src/models/errors/agentCode.errors';
 import type { IAgentCode } from '@src/types/agentCode';
 import type { IBaseReq } from '@src/models/interfaces/base.interface';
 
@@ -494,6 +494,146 @@ describe('AgentCodeController.update', () => {
     const next = makeNext();
 
     await agentCodeController.update(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0][0];
+    expect(err).toBeInstanceOf(ControllerError);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});
+
+/******************************************************************************
+  Test suite — AgentCodeController.remove
+******************************************************************************/
+
+function makeRemoveReq(overrides: Partial<IBaseReq> = {}): IBaseReq {
+  return {
+    headers: { authorization: `Bearer ${USER_TOKEN}` },
+    params: { agentCode: 'DEL001' },
+    body: {},
+    user: { id: ADMIN_ID, tenant_id: TENANT_ID, role: 'admin' },
+    ...overrides,
+  } as unknown as IBaseReq;
+}
+
+describe('AgentCodeController.remove', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('returns 200 { success: true } on successful deletion', async () => {
+    jest
+      .spyOn(agentCodeService, 'remove')
+      .mockResolvedValue(undefined);
+
+    const req = makeRemoveReq();
+    const res = makeRes();
+    const next = makeNext();
+
+    await agentCodeController.remove(req, res, next as NextFunction);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ success: true });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls agentCodeService.remove with agentCode from params, tenantId from JWT, and bearer token', async () => {
+    const spy = jest
+      .spyOn(agentCodeService, 'remove')
+      .mockResolvedValue(undefined);
+
+    const req = makeRemoveReq();
+    const res = makeRes();
+    const next = makeNext();
+
+    await agentCodeController.remove(req, res, next as NextFunction);
+
+    expect(spy).toHaveBeenCalledWith({
+      agentCode: 'DEL001',
+      tenantId: TENANT_ID,
+      token: USER_TOKEN,
+    });
+  });
+
+  it('calls next(RouteError) with status 403 when role is not admin', async () => {
+    const req = makeRemoveReq({
+      user: { id: ADMIN_ID, tenant_id: TENANT_ID, role: 'agent' },
+    } as Partial<IBaseReq>);
+    const res = makeRes();
+    const next = makeNext();
+
+    await agentCodeController.remove(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0][0];
+    expect(err).toBeInstanceOf(RouteError);
+    expect((err as RouteError).status).toBe(403);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('calls next(RouteError) with status 403 when role is group_leader', async () => {
+    const req = makeRemoveReq({
+      user: { id: ADMIN_ID, tenant_id: TENANT_ID, role: 'group_leader' },
+    } as Partial<IBaseReq>);
+    const res = makeRes();
+    const next = makeNext();
+
+    await agentCodeController.remove(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0][0];
+    expect(err).toBeInstanceOf(RouteError);
+    expect((err as RouteError).status).toBe(403);
+  });
+
+  it('calls next(RouteError) with status 404 when service throws AgentCodeNotFoundError', async () => {
+    jest
+      .spyOn(agentCodeService, 'remove')
+      .mockRejectedValue(new AgentCodeNotFoundError());
+
+    const req = makeRemoveReq();
+    const res = makeRes();
+    const next = makeNext();
+
+    await agentCodeController.remove(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0][0];
+    expect(err).toBeInstanceOf(RouteError);
+    expect((err as RouteError).status).toBe(404);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('calls next(RouteError) with status 409 when service throws AgentCodeInUseError', async () => {
+    jest
+      .spyOn(agentCodeService, 'remove')
+      .mockRejectedValue(new AgentCodeInUseError());
+
+    const req = makeRemoveReq();
+    const res = makeRes();
+    const next = makeNext();
+
+    await agentCodeController.remove(req, res, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0][0];
+    expect(err).toBeInstanceOf(RouteError);
+    expect((err as RouteError).status).toBe(409);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('calls next(ControllerError) for unexpected service errors', async () => {
+    jest
+      .spyOn(agentCodeService, 'remove')
+      .mockRejectedValue(new Error('unexpected failure'));
+
+    const req = makeRemoveReq();
+    const res = makeRes();
+    const next = makeNext();
+
+    await agentCodeController.remove(req, res, next as NextFunction);
 
     expect(next).toHaveBeenCalledTimes(1);
     const err = next.mock.calls[0][0];

--- a/tests/unit/agentCodes/agentCode.repository.test.ts
+++ b/tests/unit/agentCodes/agentCode.repository.test.ts
@@ -32,11 +32,13 @@ jest.mock('@src/services/supabase.service', () => ({
     userUpsert: jest.fn(),
     userSelect: jest.fn(),
     userUpdate: jest.fn(),
+    userDelete: jest.fn(),
   },
   supabaseService: {
     userUpsert: jest.fn(),
     userSelect: jest.fn(),
     userUpdate: jest.fn(),
+    userDelete: jest.fn(),
   },
 }));
 
@@ -44,6 +46,7 @@ import { agentCodeRepository } from '@src/repositories/agentCode.repository';
 import supabaseService from '@src/services/supabase.service';
 import { RepositoryError } from '@src/models/errors/layer.errors';
 import { AgentCodeNotFoundError, AgentCodeConflictError } from '@src/models/errors/agentCode.errors';
+import type { IAgentCode } from '@src/types/agentCode';
 
 /******************************************************************************
   Fixtures
@@ -403,6 +406,203 @@ describe('AgentCodeRepository.update', () => {
         { tenant_id: TENANT_ID, agent_code: 'OLD001' },
         { agent_code: 'NEW001', updated_at: '2026-05-12T08:00:00.000Z' },
       ),
+    ).rejects.toBeInstanceOf(RepositoryError);
+  });
+});
+
+/******************************************************************************
+  Test suite — AgentCodeRepository.findByTenantAndCode
+******************************************************************************/
+
+const mockFindRow = {
+  id: 'uuid-find-1',
+  tenant_id: TENANT_ID,
+  agent_code: 'FIND001',
+  user_id: null,
+  is_used: false,
+  created_at: '2026-05-01T10:00:00.000Z',
+  updated_at: '2026-05-01T10:00:00.000Z',
+};
+
+const expectedFindResult: IAgentCode = {
+  agent_code: 'FIND001',
+  is_used: false,
+  user_id: null,
+  created_at: '2026-05-01T10:00:00.000Z',
+  updated_at: '2026-05-01T10:00:00.000Z',
+};
+
+describe('AgentCodeRepository.findByTenantAndCode', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('returns mapped IAgentCode when a matching row is found', async () => {
+    jest.spyOn(supabaseService, 'userSelect').mockResolvedValue({
+      data: [mockFindRow],
+      error: null,
+    } as any);
+
+    const result = await agentCodeRepository.findByTenantAndCode(USER_TOKEN, {
+      tenant_id: TENANT_ID,
+      agent_code: 'FIND001',
+    });
+
+    expect(result).toEqual(expectedFindResult);
+  });
+
+  it('calls supabaseService.userSelect with correct table, columns, and filters', async () => {
+    jest.spyOn(supabaseService, 'userSelect').mockResolvedValue({
+      data: [mockFindRow],
+      error: null,
+    } as any);
+
+    await agentCodeRepository.findByTenantAndCode(USER_TOKEN, {
+      tenant_id: TENANT_ID,
+      agent_code: 'FIND001',
+    });
+
+    expect(supabaseService.userSelect).toHaveBeenCalledWith(
+      USER_TOKEN,
+      'agent_codes',
+      '*',
+      { tenant_id: TENANT_ID, agent_code: 'FIND001' },
+    );
+  });
+
+  it('returns null when data is an empty array (no matching row)', async () => {
+    jest.spyOn(supabaseService, 'userSelect').mockResolvedValue({
+      data: [],
+      error: null,
+    } as any);
+
+    const result = await agentCodeRepository.findByTenantAndCode(USER_TOKEN, {
+      tenant_id: TENANT_ID,
+      agent_code: 'NONEXISTENT',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('throws RepositoryError when userSelect returns a truthy error object', async () => {
+    jest.spyOn(supabaseService, 'userSelect').mockResolvedValue({
+      data: null,
+      error: { message: 'permission denied' },
+    } as any);
+
+    await expect(
+      agentCodeRepository.findByTenantAndCode(USER_TOKEN, {
+        tenant_id: TENANT_ID,
+        agent_code: 'FIND001',
+      }),
+    ).rejects.toBeInstanceOf(RepositoryError);
+  });
+
+  it('throws RepositoryError when userSelect itself throws', async () => {
+    jest
+      .spyOn(supabaseService, 'userSelect')
+      .mockRejectedValue(new Error('network error'));
+
+    await expect(
+      agentCodeRepository.findByTenantAndCode(USER_TOKEN, {
+        tenant_id: TENANT_ID,
+        agent_code: 'FIND001',
+      }),
+    ).rejects.toBeInstanceOf(RepositoryError);
+  });
+});
+
+/******************************************************************************
+  Test suite — AgentCodeRepository.deleteByAgentCode
+******************************************************************************/
+
+const mockDeleteRow = {
+  id: 'uuid-del-1',
+  tenant_id: TENANT_ID,
+  agent_code: 'DEL001',
+  user_id: null,
+  is_used: false,
+  created_at: '2026-05-01T10:00:00.000Z',
+  updated_at: '2026-05-01T10:00:00.000Z',
+};
+
+describe('AgentCodeRepository.deleteByAgentCode', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('calls supabaseService.userDelete with correct table and filters', async () => {
+    jest.spyOn(supabaseService, 'userDelete').mockResolvedValue({
+      data: [mockDeleteRow],
+      error: null,
+    } as any);
+
+    await agentCodeRepository.deleteByAgentCode(USER_TOKEN, {
+      tenant_id: TENANT_ID,
+      agent_code: 'DEL001',
+    });
+
+    expect(supabaseService.userDelete).toHaveBeenCalledWith(
+      USER_TOKEN,
+      'agent_codes',
+      { tenant_id: TENANT_ID, agent_code: 'DEL001' },
+    );
+  });
+
+  it('resolves to void when deletion is successful', async () => {
+    jest.spyOn(supabaseService, 'userDelete').mockResolvedValue({
+      data: [mockDeleteRow],
+      error: null,
+    } as any);
+
+    const result = await agentCodeRepository.deleteByAgentCode(USER_TOKEN, {
+      tenant_id: TENANT_ID,
+      agent_code: 'DEL001',
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('throws RepositoryError wrapping AgentCodeNotFoundError when data is an empty array', async () => {
+    jest.spyOn(supabaseService, 'userDelete').mockResolvedValue({
+      data: [],
+      error: null,
+    } as any);
+
+    let thrown: unknown;
+    try {
+      await agentCodeRepository.deleteByAgentCode(USER_TOKEN, {
+        tenant_id: TENANT_ID,
+        agent_code: 'GHOST001',
+      });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(RepositoryError);
+    expect((thrown as RepositoryError).cause).toBeInstanceOf(AgentCodeNotFoundError);
+  });
+
+  it('throws RepositoryError when userDelete returns a truthy error object', async () => {
+    jest.spyOn(supabaseService, 'userDelete').mockResolvedValue({
+      data: null,
+      error: { message: 'delete failed: permission denied' },
+    } as any);
+
+    await expect(
+      agentCodeRepository.deleteByAgentCode(USER_TOKEN, {
+        tenant_id: TENANT_ID,
+        agent_code: 'DEL001',
+      }),
+    ).rejects.toBeInstanceOf(RepositoryError);
+  });
+
+  it('throws RepositoryError when userDelete itself throws', async () => {
+    jest
+      .spyOn(supabaseService, 'userDelete')
+      .mockRejectedValue(new Error('network error'));
+
+    await expect(
+      agentCodeRepository.deleteByAgentCode(USER_TOKEN, {
+        tenant_id: TENANT_ID,
+        agent_code: 'DEL001',
+      }),
     ).rejects.toBeInstanceOf(RepositoryError);
   });
 });

--- a/tests/unit/agentCodes/agentCode.service.test.ts
+++ b/tests/unit/agentCodes/agentCode.service.test.ts
@@ -27,7 +27,7 @@ jest.mock('@src/services/supabase.service', () => ({
 import { agentCodeService } from '@src/services/agentCode.service';
 import { agentCodeRepository } from '@src/repositories/agentCode.repository';
 import { ServiceError, RepositoryError } from '@src/models/errors/layer.errors';
-import { AgentCodeNotFoundError, AgentCodeConflictError } from '@src/models/errors/agentCode.errors';
+import { AgentCodeNotFoundError, AgentCodeConflictError, AgentCodeInUseError } from '@src/models/errors/agentCode.errors';
 import type { IAgentCode } from '@src/types/agentCode';
 
 /******************************************************************************
@@ -258,6 +258,147 @@ describe('AgentCodeService.update', () => {
       agentCodeService.update({
         currentAgentCode: 'OLD001',
         newAgentCode: 'NEW001',
+        tenantId: TENANT_ID,
+        token: USER_TOKEN,
+      }),
+    ).rejects.toBeInstanceOf(ServiceError);
+  });
+});
+
+/******************************************************************************
+  Test suite — AgentCodeService.remove
+******************************************************************************/
+
+const mockExistingUnused: IAgentCode = {
+  agent_code: 'DEL001',
+  is_used: false,
+  user_id: null,
+  created_at: '2026-05-01T10:00:00.000Z',
+  updated_at: '2026-05-01T10:00:00.000Z',
+};
+
+const mockExistingUsed: IAgentCode = {
+  agent_code: 'USED001',
+  is_used: true,
+  user_id: 'user-uuid-999',
+  created_at: '2026-05-01T10:00:00.000Z',
+  updated_at: '2026-05-01T10:00:00.000Z',
+};
+
+describe('AgentCodeService.remove', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('calls findByTenantAndCode then deleteByAgentCode on happy path', async () => {
+    const findSpy = jest
+      .spyOn(agentCodeRepository, 'findByTenantAndCode')
+      .mockResolvedValue(mockExistingUnused);
+    const deleteSpy = jest
+      .spyOn(agentCodeRepository, 'deleteByAgentCode')
+      .mockResolvedValue(undefined);
+
+    await agentCodeService.remove({
+      agentCode: 'DEL001',
+      tenantId: TENANT_ID,
+      token: USER_TOKEN,
+    });
+
+    expect(findSpy).toHaveBeenCalledWith(USER_TOKEN, {
+      tenant_id: TENANT_ID,
+      agent_code: 'DEL001',
+    });
+    expect(deleteSpy).toHaveBeenCalledWith(USER_TOKEN, {
+      tenant_id: TENANT_ID,
+      agent_code: 'DEL001',
+    });
+  });
+
+  it('resolves to void (undefined) on success', async () => {
+    jest
+      .spyOn(agentCodeRepository, 'findByTenantAndCode')
+      .mockResolvedValue(mockExistingUnused);
+    jest
+      .spyOn(agentCodeRepository, 'deleteByAgentCode')
+      .mockResolvedValue(undefined);
+
+    const result = await agentCodeService.remove({
+      agentCode: 'DEL001',
+      tenantId: TENANT_ID,
+      token: USER_TOKEN,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('throws AgentCodeNotFoundError when findByTenantAndCode returns null', async () => {
+    jest
+      .spyOn(agentCodeRepository, 'findByTenantAndCode')
+      .mockResolvedValue(null);
+
+    await expect(
+      agentCodeService.remove({
+        agentCode: 'GHOST001',
+        tenantId: TENANT_ID,
+        token: USER_TOKEN,
+      }),
+    ).rejects.toBeInstanceOf(AgentCodeNotFoundError);
+  });
+
+  it('throws AgentCodeInUseError when pre-check row has is_used: true', async () => {
+    jest
+      .spyOn(agentCodeRepository, 'findByTenantAndCode')
+      .mockResolvedValue(mockExistingUsed);
+
+    await expect(
+      agentCodeService.remove({
+        agentCode: 'USED001',
+        tenantId: TENANT_ID,
+        token: USER_TOKEN,
+      }),
+    ).rejects.toBeInstanceOf(AgentCodeInUseError);
+  });
+
+  it('does not call deleteByAgentCode when pre-check finds no row', async () => {
+    jest
+      .spyOn(agentCodeRepository, 'findByTenantAndCode')
+      .mockResolvedValue(null);
+    const deleteSpy = jest
+      .spyOn(agentCodeRepository, 'deleteByAgentCode')
+      .mockResolvedValue(undefined);
+
+    await agentCodeService.remove({
+      agentCode: 'GHOST001',
+      tenantId: TENANT_ID,
+      token: USER_TOKEN,
+    }).catch(() => {});
+
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not call deleteByAgentCode when pre-check row is in use', async () => {
+    jest
+      .spyOn(agentCodeRepository, 'findByTenantAndCode')
+      .mockResolvedValue(mockExistingUsed);
+    const deleteSpy = jest
+      .spyOn(agentCodeRepository, 'deleteByAgentCode')
+      .mockResolvedValue(undefined);
+
+    await agentCodeService.remove({
+      agentCode: 'USED001',
+      tenantId: TENANT_ID,
+      token: USER_TOKEN,
+    }).catch(() => {});
+
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it('wraps unexpected repository errors in ServiceError', async () => {
+    jest
+      .spyOn(agentCodeRepository, 'findByTenantAndCode')
+      .mockRejectedValue(new Error('unexpected db failure'));
+
+    await expect(
+      agentCodeService.remove({
+        agentCode: 'DEL001',
         tenantId: TENANT_ID,
         token: USER_TOKEN,
       }),


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/agent-codes/:agentCode` — admin-only endpoint that hard-deletes a single agent code by its current value, scoped to the caller's tenant
- Returns 409 if the code is already claimed (`isUsed: true`) to prevent orphaning a user's reference
- Returns 404 if no matching code exists in the tenant
- Returns `{ success: true }` on success (200)
- Adds `AgentCodeInUseError` domain error and `findByTenantAndCode` / `deleteByAgentCode` repo methods
- 24 new unit tests across repository, service, and controller layers
- OpenAPI spec updated with the `delete` operation under `/agent-codes/{agentCode}`

## Test plan

- [ ] `npm run type-check` — clean
- [ ] `npx jest tests/unit/agentCodes --no-coverage` — all 73 tests green
- [ ] Smoke: `DELETE /api/agent-codes/:agentCode` with admin token → 200 `{ success: true }`
- [ ] Smoke: non-existent code → 404
- [ ] Smoke: code with `isUsed: true` → 409
- [ ] Smoke: non-admin token → 403
- [ ] Verify deleted code no longer appears in `GET /api/agent-codes`