### PR TITLE
feat(leaderboard): add ACE/FYC/FYCt to leaderboard stats

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5702,6 +5702,9 @@ components:
         - sales_meetings
         - sales_successful
         - total_points
+        - ace
+        - fyc
+        - fyct
       properties:
         user_id:
           type: string
@@ -5744,6 +5747,32 @@ components:
           type: integer
           description: Pre-computed total points for this agent in the period, calculated server-side using the tenant's current point config.
           example: 26
+        ace:
+          type: number
+          description: >
+            Annualized Commission Earnings. For `period=mtd`, the current
+            calendar month's value sourced from `sales_report_mtd_fyc`; for
+            `period=ytd`, the latest available month snapshot for the current
+            year from `sales_report_ytd`. Defaults to 0 if no sales-report
+            data is available.
+          example: 12500.50
+        fyc:
+          type: number
+          description: >
+            First Year Commission. For `period=mtd`, the month-to-date delta
+            derived from the `sales_report_mtd_fyc` LAG view; for `period=ytd`,
+            the cumulative year-to-date value from `sales_report_ytd`.
+            Defaults to 0 if no sales-report data is available.
+          example: 8400
+        fyct:
+          type: number
+          description: >
+            First Year Commission Target. For `period=mtd`, the month-to-date
+            delta derived from the `sales_report_mtd_fyc` LAG view; for
+            `period=ytd`, the cumulative year-to-date value from
+            `sales_report_ytd`. Defaults to 0 if no sales-report data is
+            available.
+          example: 9000
 
     LeaderboardStatsGroupObject:
       type: object
@@ -5757,6 +5786,9 @@ components:
         - sales_meetings
         - sales_successful
         - total_points
+        - ace
+        - fyc
+        - fyct
       properties:
         group_id:
           type: string
@@ -5794,6 +5826,34 @@ components:
           type: integer
           description: Aggregated total points for all members of this group in the period, calculated server-side using the tenant's current point config.
           example: 52
+        ace:
+          type: number
+          description: >
+            Aggregated Annualized Commission Earnings across all group
+            members in the period. For `period=mtd`, the current calendar
+            month's value sourced from `sales_report_mtd_fyc`; for
+            `period=ytd`, the latest available month snapshot for the current
+            year from `sales_report_ytd`. Members with no sales-report data
+            contribute 0.
+          example: 62500.50
+        fyc:
+          type: number
+          description: >
+            Aggregated First Year Commission across all group members in the
+            period. For `period=mtd`, the month-to-date delta derived from
+            the `sales_report_mtd_fyc` LAG view; for `period=ytd`, the
+            cumulative year-to-date value from `sales_report_ytd`. Members
+            with no sales-report data contribute 0.
+          example: 42000
+        fyct:
+          type: number
+          description: >
+            Aggregated First Year Commission Target across all group members
+            in the period. For `period=mtd`, the month-to-date delta derived
+            from the `sales_report_mtd_fyc` LAG view; for `period=ytd`, the
+            cumulative year-to-date value from `sales_report_ytd`. Members
+            with no sales-report data contribute 0.
+          example: 45000
 
     AgentPointsObject:
       type: object

--- a/src/repositories/leaderboard.repository.ts
+++ b/src/repositories/leaderboard.repository.ts
@@ -16,11 +16,12 @@ class LeaderboardRepository {
     }
   }
 
-  async getStats(tenantId: string, periodStart: string) {
+  async getStats(tenantId: string, periodStart: string, period: 'mtd' | 'ytd') {
     try {
       return await supabaseService.adminRpc('get_leaderboard_stats', {
         p_tenant_id: tenantId,
         p_period_start: periodStart,
+        p_period: period,
       });
     } catch (error) {
       handleRepositoryError('LeaderboardRepository.getStats', error);

--- a/src/services/leaderboard.service.ts
+++ b/src/services/leaderboard.service.ts
@@ -29,7 +29,7 @@ class LeaderboardService {
           ? new Date(now.getFullYear(), now.getMonth(), 1).toISOString()
           : new Date(now.getFullYear(), 0, 1).toISOString();
 
-      const response = await leaderboardRepository.getStats(tenantId, periodStart);
+      const response = await leaderboardRepository.getStats(tenantId, periodStart, period);
       const raw = (response?.data ?? {}) as {
         individual?: ILeaderboardStatsIndividual[];
         groups?: ILeaderboardStatsGroup[];

--- a/src/services/leaderboard.service.ts
+++ b/src/services/leaderboard.service.ts
@@ -26,8 +26,8 @@ class LeaderboardService {
       const now = new Date();
       const periodStart =
         period === 'mtd'
-          ? new Date(now.getFullYear(), now.getMonth(), 1).toISOString()
-          : new Date(now.getFullYear(), 0, 1).toISOString();
+          ? new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString()
+          : new Date(Date.UTC(now.getUTCFullYear(), 0, 1)).toISOString();
 
       const response = await leaderboardRepository.getStats(tenantId, periodStart, period);
       const raw = (response?.data ?? {}) as {

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1087,10 +1087,19 @@ export type Database = {
         Returns: Json
       }
       get_group_stats: { Args: never; Returns: Json }
-      get_leaderboard_stats: {
-        Args: { p_period_start: string; p_tenant_id: string }
-        Returns: Json
-      }
+      get_leaderboard_stats:
+        | {
+            Args: { p_period_start: string; p_tenant_id: string }
+            Returns: Json
+          }
+        | {
+            Args: {
+              p_period?: string
+              p_period_start: string
+              p_tenant_id: string
+            }
+            Returns: Json
+          }
       reconcile_stale_report_jobs: { Args: never; Returns: undefined }
     }
     Enums: {

--- a/src/types/leaderboard.types.ts
+++ b/src/types/leaderboard.types.ts
@@ -24,6 +24,9 @@ export type ILeaderboardStatsIndividual = {
   sales_meetings: number;
   sales_successful: number;
   total_points: number;
+  ace: number;
+  fyc: number;
+  fyct: number;
 };
 
 export type ILeaderboardStatsGroup = {
@@ -36,6 +39,9 @@ export type ILeaderboardStatsGroup = {
   sales_meetings: number;
   sales_successful: number;
   total_points: number;
+  ace: number;
+  fyc: number;
+  fyct: number;
 };
 
 export type ILeaderboardStats = {

--- a/supabase/migrations/20260603163303_add_sales_metrics_to_leaderboard_stats.sql
+++ b/supabase/migrations/20260603163303_add_sales_metrics_to_leaderboard_stats.sql
@@ -1,0 +1,178 @@
+-- Extend get_leaderboard_stats to also surface ACE / FYC / FYCt per user and per group.
+-- MTD pulls from sales_report_mtd_fyc for the current (year, month).
+-- YTD pulls the latest available month row for the current year from sales_report_ytd.
+-- Existing prospect/point logic is preserved verbatim; sales metrics are introduced via
+-- LEFT JOINs against `sales` (per-user) and `group_sales` (per-group) CTEs so they don't
+-- cartesian-multiply with the prospect rows.
+
+CREATE OR REPLACE FUNCTION get_leaderboard_stats(
+  p_tenant_id    UUID,
+  p_period_start TIMESTAMPTZ,
+  p_period       TEXT DEFAULT 'mtd'
+)
+RETURNS JSON AS $$
+DECLARE
+  v_year       SMALLINT := EXTRACT(YEAR  FROM p_period_start)::SMALLINT;
+  v_month      SMALLINT := EXTRACT(MONTH FROM p_period_start)::SMALLINT;
+  v_individual JSON;
+  v_groups     JSON;
+BEGIN
+  -- Individual stats per agent/group_leader
+  WITH sales AS (
+    SELECT
+      s.user_id,
+      COALESCE(s.ace,  0)::FLOAT8 AS ace,
+      COALESCE(s.fyc,  0)::FLOAT8 AS fyc,
+      COALESCE(s.fyct, 0)::FLOAT8 AS fyct
+    FROM (
+      -- MTD branch
+      SELECT user_id, ace, fyc_mtd AS fyc, fyct_mtd AS fyct
+      FROM   public.sales_report_mtd_fyc
+      WHERE  p_period = 'mtd'
+        AND  tenant_id = p_tenant_id
+        AND  year  = v_year
+        AND  month = v_month
+      UNION ALL
+      -- YTD branch: latest month row per user for the current year
+      SELECT user_id, ace, fyc, fyct FROM (
+        SELECT DISTINCT ON (user_id) user_id, ace, fyc, fyct
+        FROM   public.sales_report_ytd
+        WHERE  p_period = 'ytd'
+          AND  tenant_id = p_tenant_id
+          AND  year = v_year
+        ORDER  BY user_id, month DESC
+      ) ytd_latest
+    ) s
+  )
+  SELECT json_agg(individual_stats)
+  INTO v_individual
+  FROM (
+    SELECT
+      u.id AS user_id,
+      u.name,
+      u.agent_code,
+      u.group_id,
+      g.name AS group_name,
+      COUNT(p.id) FILTER (WHERE p.created_at >= p_period_start) AS prospects_added,
+      COUNT(p.id) FILTER (
+        WHERE p.appointment_status = 'done'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS appointments_completed,
+      COUNT(p.id) FILTER (
+        WHERE p.current_stage = 'sales'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_meetings,
+      COUNT(p.id) FILTER (
+        WHERE p.sales_outcome = 'successful'
+        AND COALESCE(p.sales_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_successful,
+      COALESCE((
+        SELECT SUM(pt.points)
+        FROM public.point_transactions pt
+        WHERE pt.user_id   = u.id
+          AND pt.tenant_id = p_tenant_id
+          AND pt.created_at >= p_period_start
+      ), 0) AS total_points,
+      COALESCE(MAX(s.ace),  0) AS ace,
+      COALESCE(MAX(s.fyc),  0) AS fyc,
+      COALESCE(MAX(s.fyct), 0) AS fyct
+    FROM public.users u
+    LEFT JOIN public.groups g ON g.id = u.group_id
+    LEFT JOIN public.prospects p ON p.agent_id = u.id AND p.tenant_id = p_tenant_id
+    LEFT JOIN sales s ON s.user_id = u.id
+    WHERE u.tenant_id = p_tenant_id
+      AND u.role IN ('agent', 'group_leader')
+      AND u.status = 'active'
+    GROUP BY u.id, u.name, u.agent_code, u.group_id, g.name
+  ) individual_stats;
+
+  -- Group aggregated stats
+  WITH sales AS (
+    SELECT
+      s.user_id,
+      COALESCE(s.ace,  0)::FLOAT8 AS ace,
+      COALESCE(s.fyc,  0)::FLOAT8 AS fyc,
+      COALESCE(s.fyct, 0)::FLOAT8 AS fyct
+    FROM (
+      SELECT user_id, ace, fyc_mtd AS fyc, fyct_mtd AS fyct
+      FROM   public.sales_report_mtd_fyc
+      WHERE  p_period = 'mtd'
+        AND  tenant_id = p_tenant_id
+        AND  year  = v_year
+        AND  month = v_month
+      UNION ALL
+      SELECT user_id, ace, fyc, fyct FROM (
+        SELECT DISTINCT ON (user_id) user_id, ace, fyc, fyct
+        FROM   public.sales_report_ytd
+        WHERE  p_period = 'ytd'
+          AND  tenant_id = p_tenant_id
+          AND  year = v_year
+        ORDER  BY user_id, month DESC
+      ) ytd_latest
+    ) s
+  ),
+  group_sales AS (
+    SELECT
+      u.group_id,
+      SUM(s.ace)  AS ace,
+      SUM(s.fyc)  AS fyc,
+      SUM(s.fyct) AS fyct
+    FROM   public.users u
+    JOIN   sales s ON s.user_id = u.id
+    WHERE  u.tenant_id = p_tenant_id
+      AND  u.status = 'active'
+      AND  u.role IN ('agent', 'group_leader')
+    GROUP  BY u.group_id
+  )
+  SELECT json_agg(group_stats)
+  INTO v_groups
+  FROM (
+    SELECT
+      g.id AS group_id,
+      g.name AS group_name,
+      leader.name AS leader_name,
+      COUNT(DISTINCT u.id) AS member_count,
+      COUNT(p.id) FILTER (WHERE p.created_at >= p_period_start) AS prospects_added,
+      COUNT(p.id) FILTER (
+        WHERE p.appointment_status = 'done'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS appointments_completed,
+      COUNT(p.id) FILTER (
+        WHERE p.current_stage = 'sales'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_meetings,
+      COUNT(p.id) FILTER (
+        WHERE p.sales_outcome = 'successful'
+        AND COALESCE(p.sales_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_successful,
+      COALESCE((
+        SELECT SUM(pt.points)
+        FROM public.point_transactions pt
+        WHERE pt.tenant_id = p_tenant_id
+          AND pt.created_at >= p_period_start
+          AND pt.user_id IN (
+            SELECT u2.id FROM public.users u2
+            WHERE u2.group_id   = g.id
+              AND u2.tenant_id  = p_tenant_id
+              AND u2.role IN ('agent', 'group_leader')
+              AND u2.status = 'active'
+          )
+      ), 0) AS total_points,
+      COALESCE(MAX(gs.ace),  0) AS ace,
+      COALESCE(MAX(gs.fyc),  0) AS fyc,
+      COALESCE(MAX(gs.fyct), 0) AS fyct
+    FROM public.groups g
+    LEFT JOIN public.users leader ON leader.id = g.leader_id AND leader.tenant_id = p_tenant_id
+    JOIN public.users u ON u.group_id = g.id AND u.role IN ('agent', 'group_leader') AND u.tenant_id = p_tenant_id AND u.status = 'active'
+    LEFT JOIN public.prospects p ON p.agent_id = u.id AND p.tenant_id = p_tenant_id
+    LEFT JOIN group_sales gs ON gs.group_id = g.id
+    WHERE g.tenant_id = p_tenant_id
+    GROUP BY g.id, g.name, leader.name
+  ) group_stats;
+
+  RETURN json_build_object(
+    'individual', COALESCE(v_individual, '[]'::json),
+    'groups', COALESCE(v_groups, '[]'::json)
+  );
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER;

--- a/tests/integration/leaderboard.test.ts
+++ b/tests/integration/leaderboard.test.ts
@@ -251,12 +251,18 @@ describe('GET /api/leaderboard/stats — happy path (admin)', () => {
       expect(entry).toHaveProperty('sales_meetings');
       expect(entry).toHaveProperty('sales_successful');
       expect(entry).toHaveProperty('total_points');
+      expect(entry).toHaveProperty('ace');
+      expect(entry).toHaveProperty('fyc');
+      expect(entry).toHaveProperty('fyct');
 
       expect(typeof entry['prospects_added']).toBe('number');
       expect(typeof entry['appointments_completed']).toBe('number');
       expect(typeof entry['sales_meetings']).toBe('number');
       expect(typeof entry['sales_successful']).toBe('number');
       expect(typeof entry['total_points']).toBe('number');
+      expect(typeof entry['ace']).toBe('number');
+      expect(typeof entry['fyc']).toBe('number');
+      expect(typeof entry['fyct']).toBe('number');
     }
   });
 
@@ -286,6 +292,9 @@ describe('GET /api/leaderboard/stats — happy path (admin)', () => {
       expect(entry).toHaveProperty('sales_meetings');
       expect(entry).toHaveProperty('sales_successful');
       expect(entry).toHaveProperty('total_points');
+      expect(entry).toHaveProperty('ace');
+      expect(entry).toHaveProperty('fyc');
+      expect(entry).toHaveProperty('fyct');
 
       expect(typeof entry['member_count']).toBe('number');
       expect(typeof entry['prospects_added']).toBe('number');
@@ -293,6 +302,9 @@ describe('GET /api/leaderboard/stats — happy path (admin)', () => {
       expect(typeof entry['sales_meetings']).toBe('number');
       expect(typeof entry['sales_successful']).toBe('number');
       expect(typeof entry['total_points']).toBe('number');
+      expect(typeof entry['ace']).toBe('number');
+      expect(typeof entry['fyc']).toBe('number');
+      expect(typeof entry['fyct']).toBe('number');
     }
   });
 });

--- a/tests/unit/leaderboard/leaderboard.repository.test.ts
+++ b/tests/unit/leaderboard/leaderboard.repository.test.ts
@@ -1,0 +1,121 @@
+// Supply env vars before env.ts runs so the validation guards do not throw
+process.env.SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+
+jest.mock('@src/services/logging.service', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+  loggingService: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('@src/services/supabase.service', () => ({
+  __esModule: true,
+  default: { adminRpc: jest.fn() },
+}));
+
+import leaderboardRepository from '@src/repositories/leaderboard.repository';
+import supabaseService from '@src/services/supabase.service';
+import { RepositoryError } from '@src/models/errors/layer.errors';
+
+/******************************************************************************
+  Fixtures
+******************************************************************************/
+
+const TENANT_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const PERIOD_START = '2026-06-01T00:00:00.000Z';
+
+/******************************************************************************
+  Test suite — LeaderboardRepository.getStats
+******************************************************************************/
+
+describe('LeaderboardRepository.getStats', () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it('calls adminRpc with get_leaderboard_stats, tenant_id, period_start, and p_period="mtd"', async () => {
+    (supabaseService.adminRpc as jest.Mock).mockResolvedValue({
+      data: { individual: [], groups: [] },
+      error: null,
+    });
+
+    await leaderboardRepository.getStats(TENANT_ID, PERIOD_START, 'mtd');
+
+    expect(supabaseService.adminRpc).toHaveBeenCalledTimes(1);
+    expect(supabaseService.adminRpc).toHaveBeenCalledWith(
+      'get_leaderboard_stats',
+      {
+        p_tenant_id: TENANT_ID,
+        p_period_start: PERIOD_START,
+        p_period: 'mtd',
+      },
+    );
+  });
+
+  it('calls adminRpc with p_period="ytd" when period is ytd', async () => {
+    (supabaseService.adminRpc as jest.Mock).mockResolvedValue({
+      data: { individual: [], groups: [] },
+      error: null,
+    });
+
+    await leaderboardRepository.getStats(TENANT_ID, PERIOD_START, 'ytd');
+
+    expect(supabaseService.adminRpc).toHaveBeenCalledWith(
+      'get_leaderboard_stats',
+      {
+        p_tenant_id: TENANT_ID,
+        p_period_start: PERIOD_START,
+        p_period: 'ytd',
+      },
+    );
+  });
+
+  it('returns the raw RPC response unchanged for the service to interpret', async () => {
+    const rpcResponse = {
+      data: {
+        individual: [
+          {
+            user_id: 'u1',
+            name: 'A',
+            agent_code: 'X1',
+            group_id: null,
+            group_name: null,
+            prospects_added: 0,
+            appointments_completed: 0,
+            sales_meetings: 0,
+            sales_successful: 0,
+            total_points: 0,
+            ace: 0,
+            fyc: 0,
+            fyct: 0,
+          },
+        ],
+        groups: [],
+      },
+      error: null,
+    };
+    (supabaseService.adminRpc as jest.Mock).mockResolvedValue(rpcResponse);
+
+    const result = await leaderboardRepository.getStats(TENANT_ID, PERIOD_START, 'mtd');
+
+    expect(result).toEqual(rpcResponse);
+  });
+
+  it('wraps unexpected adminRpc errors in RepositoryError', async () => {
+    (supabaseService.adminRpc as jest.Mock).mockRejectedValue(
+      new Error('rpc network failure'),
+    );
+
+    await expect(
+      leaderboardRepository.getStats(TENANT_ID, PERIOD_START, 'mtd'),
+    ).rejects.toBeInstanceOf(RepositoryError);
+  });
+});

--- a/tests/unit/leaderboard/leaderboard.service.test.ts
+++ b/tests/unit/leaderboard/leaderboard.service.test.ts
@@ -124,7 +124,7 @@ describe('LeaderboardService.getStats', () => {
     );
   });
 
-  it('passes a periodStart at the start of the current month when period="mtd"', async () => {
+  it('passes a periodStart at the start of the current month in UTC when period="mtd"', async () => {
     const spy = jest.spyOn(leaderboardRepository, 'getStats').mockResolvedValue({
       data: { individual: [], groups: [] },
     } as never);
@@ -134,12 +134,13 @@ describe('LeaderboardService.getStats', () => {
     const periodStart = spy.mock.calls[0][1];
     const parsed = new Date(periodStart);
     const now = new Date();
-    expect(parsed.getFullYear()).toBe(now.getFullYear());
-    expect(parsed.getMonth()).toBe(now.getMonth());
-    expect(parsed.getDate()).toBe(1);
+    expect(parsed.getUTCFullYear()).toBe(now.getUTCFullYear());
+    expect(parsed.getUTCMonth()).toBe(now.getUTCMonth());
+    expect(parsed.getUTCDate()).toBe(1);
+    expect(parsed.getUTCHours()).toBe(0);
   });
 
-  it('passes a periodStart at the start of the current year when period="ytd"', async () => {
+  it('passes a periodStart at the start of the current year in UTC when period="ytd"', async () => {
     const spy = jest.spyOn(leaderboardRepository, 'getStats').mockResolvedValue({
       data: { individual: [], groups: [] },
     } as never);
@@ -149,9 +150,10 @@ describe('LeaderboardService.getStats', () => {
     const periodStart = spy.mock.calls[0][1];
     const parsed = new Date(periodStart);
     const now = new Date();
-    expect(parsed.getFullYear()).toBe(now.getFullYear());
-    expect(parsed.getMonth()).toBe(0);
-    expect(parsed.getDate()).toBe(1);
+    expect(parsed.getUTCFullYear()).toBe(now.getUTCFullYear());
+    expect(parsed.getUTCMonth()).toBe(0);
+    expect(parsed.getUTCDate()).toBe(1);
+    expect(parsed.getUTCHours()).toBe(0);
   });
 
   it('returns ace, fyc, fyct on individual entries untouched from the RPC response', async () => {

--- a/tests/unit/leaderboard/leaderboard.service.test.ts
+++ b/tests/unit/leaderboard/leaderboard.service.test.ts
@@ -1,0 +1,218 @@
+// Supply env vars before env.ts runs so the validation guards do not throw
+process.env.SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+
+jest.mock('@src/services/logging.service', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+  loggingService: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('@src/services/supabase.service', () => ({
+  __esModule: true,
+  default: { adminRpc: jest.fn() },
+}));
+
+import leaderboardService from '@src/services/leaderboard.service';
+import leaderboardRepository from '@src/repositories/leaderboard.repository';
+import { ServiceError } from '@src/models/errors/layer.errors';
+import type {
+  ILeaderboardStatsGroup,
+  ILeaderboardStatsIndividual,
+} from '@src/types/leaderboard.types';
+
+/******************************************************************************
+  Fixtures
+******************************************************************************/
+
+const TENANT_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+const mockIndividual: ILeaderboardStatsIndividual[] = [
+  {
+    user_id: 'user-uuid-1',
+    name: 'Alice Agent',
+    agent_code: 'AGT001',
+    group_id: 'group-uuid-1',
+    group_name: 'MDRT Stars',
+    prospects_added: 12,
+    appointments_completed: 8,
+    sales_meetings: 5,
+    sales_successful: 3,
+    total_points: 150,
+    ace: 50000.5,
+    fyc: 12000,
+    fyct: 8000,
+  },
+  {
+    user_id: 'user-uuid-2',
+    name: 'Bob Agent',
+    agent_code: 'AGT002',
+    group_id: null,
+    group_name: null,
+    prospects_added: 0,
+    appointments_completed: 0,
+    sales_meetings: 0,
+    sales_successful: 0,
+    total_points: 0,
+    ace: 0,
+    fyc: 0,
+    fyct: 0,
+  },
+];
+
+const mockGroups: ILeaderboardStatsGroup[] = [
+  {
+    group_id: 'group-uuid-1',
+    group_name: 'MDRT Stars',
+    leader_name: 'Lead Leader',
+    member_count: 7,
+    prospects_added: 42,
+    appointments_completed: 28,
+    sales_meetings: 14,
+    sales_successful: 9,
+    total_points: 540,
+    ace: 250000.75,
+    fyc: 60000,
+    fyct: 40000,
+  },
+];
+
+/******************************************************************************
+  Test suite — LeaderboardService.getStats
+******************************************************************************/
+
+describe('LeaderboardService.getStats', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('forwards period="mtd" to the repository', async () => {
+    const spy = jest.spyOn(leaderboardRepository, 'getStats').mockResolvedValue({
+      data: { individual: mockIndividual, groups: mockGroups },
+    } as never);
+
+    await leaderboardService.getStats(TENANT_ID, 'mtd');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.any(String),
+      'mtd',
+    );
+  });
+
+  it('forwards period="ytd" to the repository', async () => {
+    const spy = jest.spyOn(leaderboardRepository, 'getStats').mockResolvedValue({
+      data: { individual: mockIndividual, groups: mockGroups },
+    } as never);
+
+    await leaderboardService.getStats(TENANT_ID, 'ytd');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      TENANT_ID,
+      expect.any(String),
+      'ytd',
+    );
+  });
+
+  it('passes a periodStart at the start of the current month when period="mtd"', async () => {
+    const spy = jest.spyOn(leaderboardRepository, 'getStats').mockResolvedValue({
+      data: { individual: [], groups: [] },
+    } as never);
+
+    await leaderboardService.getStats(TENANT_ID, 'mtd');
+
+    const periodStart = spy.mock.calls[0][1];
+    const parsed = new Date(periodStart);
+    const now = new Date();
+    expect(parsed.getFullYear()).toBe(now.getFullYear());
+    expect(parsed.getMonth()).toBe(now.getMonth());
+    expect(parsed.getDate()).toBe(1);
+  });
+
+  it('passes a periodStart at the start of the current year when period="ytd"', async () => {
+    const spy = jest.spyOn(leaderboardRepository, 'getStats').mockResolvedValue({
+      data: { individual: [], groups: [] },
+    } as never);
+
+    await leaderboardService.getStats(TENANT_ID, 'ytd');
+
+    const periodStart = spy.mock.calls[0][1];
+    const parsed = new Date(periodStart);
+    const now = new Date();
+    expect(parsed.getFullYear()).toBe(now.getFullYear());
+    expect(parsed.getMonth()).toBe(0);
+    expect(parsed.getDate()).toBe(1);
+  });
+
+  it('returns ace, fyc, fyct on individual entries untouched from the RPC response', async () => {
+    jest.spyOn(leaderboardRepository, 'getStats').mockResolvedValue({
+      data: { individual: mockIndividual, groups: mockGroups },
+    } as never);
+
+    const result = await leaderboardService.getStats(TENANT_ID, 'mtd');
+
+    expect(result.individual).toEqual(mockIndividual);
+    expect(result.individual[0].ace).toBe(50000.5);
+    expect(result.individual[0].fyc).toBe(12000);
+    expect(result.individual[0].fyct).toBe(8000);
+    expect(result.individual[1].ace).toBe(0);
+    expect(result.individual[1].fyc).toBe(0);
+    expect(result.individual[1].fyct).toBe(0);
+  });
+
+  it('returns ace, fyc, fyct on group entries untouched from the RPC response', async () => {
+    jest.spyOn(leaderboardRepository, 'getStats').mockResolvedValue({
+      data: { individual: mockIndividual, groups: mockGroups },
+    } as never);
+
+    const result = await leaderboardService.getStats(TENANT_ID, 'mtd');
+
+    expect(result.groups).toEqual(mockGroups);
+    expect(result.groups[0].ace).toBe(250000.75);
+    expect(result.groups[0].fyc).toBe(60000);
+    expect(result.groups[0].fyct).toBe(40000);
+  });
+
+  it('echoes the period back on the response payload', async () => {
+    jest.spyOn(leaderboardRepository, 'getStats').mockResolvedValue({
+      data: { individual: [], groups: [] },
+    } as never);
+
+    const mtd = await leaderboardService.getStats(TENANT_ID, 'mtd');
+    const ytd = await leaderboardService.getStats(TENANT_ID, 'ytd');
+
+    expect(mtd.period).toBe('mtd');
+    expect(ytd.period).toBe('ytd');
+  });
+
+  it('returns empty arrays when the RPC payload is empty', async () => {
+    jest.spyOn(leaderboardRepository, 'getStats').mockResolvedValue({
+      data: {},
+    } as never);
+
+    const result = await leaderboardService.getStats(TENANT_ID, 'mtd');
+
+    expect(result.individual).toEqual([]);
+    expect(result.groups).toEqual([]);
+  });
+
+  it('wraps unexpected repository errors in ServiceError', async () => {
+    jest
+      .spyOn(leaderboardRepository, 'getStats')
+      .mockRejectedValue(new Error('rpc failure'));
+
+    await expect(
+      leaderboardService.getStats(TENANT_ID, 'mtd'),
+    ).rejects.toBeInstanceOf(ServiceError);
+  });
+});


### PR DESCRIPTION
## Summary

Extends `GET /api/leaderboard/stats?period=mtd|ytd` to return **ACE**, **FYC**, and **FYCt** on every row of both `individual[]` and `groups[]`, sourced from the sales-report tables that back `/api/sales-reports`. Tenant-wide visibility (unchanged from the existing leaderboard). **ACS is deferred** to a follow-up pending its formula.

## What changed

- **RPC** (`get_leaderboard_stats`): joins sales-report data per user (`sales`) and per group (`group_sales` CTE, summed across active members), exposing `ace`/`fyc`/`fyct` cast to `FLOAT8`. A new `p_period` arg routes the lookup:
  - `period=mtd` → current month's row in the `sales_report_mtd_fyc` view (FYC/FYCt are LAG-derived MTD deltas; ACE is the month's direct value).
  - `period=ytd` → latest available month row for the current year in `sales_report_ytd` (cumulative YTD, taken straight from the column — not summed).
  - Missing sales-report rows default to `0`.
- **API layers**: `period` is threaded service → repository → RPC; new fields added to `ILeaderboardStatsIndividual` / `ILeaderboardStatsGroup`.
- **Timezone fix**: the period boundary is now built in **UTC** (`Date.UTC(...)`) so the RPC's UTC-based month extraction resolves the correct calendar month. Previously, local-time construction rolled the instant into the prior month on UTC+ servers, causing `period=mtd` to return the **previous month's** ACE/FYC/FYCt.
- **Docs**: `LeaderboardStatsIndividualObject` / `LeaderboardStatsGroupObject` updated in `openapi.yaml`.

## Testing

- Unit: `tests/unit/leaderboard/` — service period-forwarding, UTC boundary, field passthrough; repository RPC-arg shape.
- Integration: `tests/integration/leaderboard.test.ts` — asserts `ace`/`fyc`/`fyct` present end-to-end for both periods.
- `npm run type-check` clean; 27/27 leaderboard tests pass.

## Notes / follow-ups

- **Types regen**: `src/types/database.types.ts` was hand-edited for the new `p_period` arg; regenerate via `supabase gen types` against the linked project to stay authoritative.
- **ACS** — pending formula.
- Accepted boundary nuance: the UTC period start = 8am SGT, so live `>=` metrics (prospects/points) exclude the first 8 hours of the SGT month. Negligible for a leaderboard; ACE/FYC/FYCt (monthly ETL, exact-month match) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)