### PR TITLE
feat(leaderboard): add ACS (Average Case Size) to leaderboard stats

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5705,6 +5705,7 @@ components:
         - ace
         - fyc
         - fyct
+        - acs
       properties:
         user_id:
           type: string
@@ -5773,6 +5774,14 @@ components:
             `sales_report_ytd`. Defaults to 0 if no sales-report data is
             available.
           example: 9000
+        acs:
+          type: number
+          description: >
+            Average Case Size = ACE / NOC for the period. For period=mtd uses
+            the current month's ACE and NOC; for period=ytd uses the latest
+            cumulative snapshot for the current year. Returns 0 when there are
+            no cases (NOC = 0).
+          example: 12500.50
 
     LeaderboardStatsGroupObject:
       type: object
@@ -5789,6 +5798,7 @@ components:
         - ace
         - fyc
         - fyct
+        - acs
       properties:
         group_id:
           type: string
@@ -5854,6 +5864,14 @@ components:
             cumulative year-to-date value from `sales_report_ytd`. Members
             with no sales-report data contribute 0.
           example: 45000
+        acs:
+          type: number
+          description: >
+            Average Case Size = ACE / NOC for the period. For period=mtd uses
+            the current month's ACE and NOC; for period=ytd uses the latest
+            cumulative snapshot for the current year. Returns 0 when there are
+            no cases (NOC = 0).
+          example: 18750.25
 
     AgentPointsObject:
       type: object

--- a/src/types/leaderboard.types.ts
+++ b/src/types/leaderboard.types.ts
@@ -27,6 +27,7 @@ export type ILeaderboardStatsIndividual = {
   ace: number;
   fyc: number;
   fyct: number;
+  acs: number;
 };
 
 export type ILeaderboardStatsGroup = {
@@ -42,6 +43,7 @@ export type ILeaderboardStatsGroup = {
   ace: number;
   fyc: number;
   fyct: number;
+  acs: number;
 };
 
 export type ILeaderboardStats = {

--- a/supabase/migrations/20260606073305_add_acs_to_leaderboard_stats.sql
+++ b/supabase/migrations/20260606073305_add_acs_to_leaderboard_stats.sql
@@ -1,0 +1,183 @@
+-- Extend get_leaderboard_stats to also surface ACS (Average Case Size = ACE / NOC)
+-- per user and per group, alongside the existing ACE / FYC / FYCt metrics.
+-- NOC is threaded through the `sales` CTE (from sales_report_mtd_fyc for MTD and
+-- sales_report_ytd for YTD). Individual ACS = ace / noc; group ACS = SUM(ace) / SUM(noc).
+-- NOC = 0 yields ACS = 0 via NULLIF + COALESCE. Quotient is raw FLOAT8 (no rounding).
+-- Signature is unchanged, so this is a plain CREATE OR REPLACE.
+
+CREATE OR REPLACE FUNCTION get_leaderboard_stats(
+  p_tenant_id    UUID,
+  p_period_start TIMESTAMPTZ,
+  p_period       TEXT DEFAULT 'mtd'
+)
+RETURNS JSON AS $$
+DECLARE
+  v_year       SMALLINT := EXTRACT(YEAR  FROM p_period_start)::SMALLINT;
+  v_month      SMALLINT := EXTRACT(MONTH FROM p_period_start)::SMALLINT;
+  v_individual JSON;
+  v_groups     JSON;
+BEGIN
+  -- Individual stats per agent/group_leader
+  WITH sales AS (
+    SELECT
+      s.user_id,
+      COALESCE(s.ace,  0)::FLOAT8 AS ace,
+      COALESCE(s.fyc,  0)::FLOAT8 AS fyc,
+      COALESCE(s.fyct, 0)::FLOAT8 AS fyct,
+      COALESCE(s.noc,  0)::FLOAT8 AS noc
+    FROM (
+      -- MTD branch
+      SELECT user_id, ace, fyc_mtd AS fyc, fyct_mtd AS fyct, noc
+      FROM   public.sales_report_mtd_fyc
+      WHERE  p_period = 'mtd'
+        AND  tenant_id = p_tenant_id
+        AND  year  = v_year
+        AND  month = v_month
+      UNION ALL
+      -- YTD branch: latest month row per user for the current year
+      SELECT user_id, ace, fyc, fyct, noc FROM (
+        SELECT DISTINCT ON (user_id) user_id, ace, fyc, fyct, noc
+        FROM   public.sales_report_ytd
+        WHERE  p_period = 'ytd'
+          AND  tenant_id = p_tenant_id
+          AND  year = v_year
+        ORDER  BY user_id, month DESC
+      ) ytd_latest
+    ) s
+  )
+  SELECT json_agg(individual_stats)
+  INTO v_individual
+  FROM (
+    SELECT
+      u.id AS user_id,
+      u.name,
+      u.agent_code,
+      u.group_id,
+      g.name AS group_name,
+      COUNT(p.id) FILTER (WHERE p.created_at >= p_period_start) AS prospects_added,
+      COUNT(p.id) FILTER (
+        WHERE p.appointment_status = 'done'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS appointments_completed,
+      COUNT(p.id) FILTER (
+        WHERE p.current_stage = 'sales'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_meetings,
+      COUNT(p.id) FILTER (
+        WHERE p.sales_outcome = 'successful'
+        AND COALESCE(p.sales_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_successful,
+      COALESCE((
+        SELECT SUM(pt.points)
+        FROM public.point_transactions pt
+        WHERE pt.user_id   = u.id
+          AND pt.tenant_id = p_tenant_id
+          AND pt.created_at >= p_period_start
+      ), 0) AS total_points,
+      COALESCE(MAX(s.ace),  0) AS ace,
+      COALESCE(MAX(s.fyc),  0) AS fyc,
+      COALESCE(MAX(s.fyct), 0) AS fyct,
+      COALESCE(MAX(s.ace) / NULLIF(MAX(s.noc), 0), 0) AS acs
+    FROM public.users u
+    LEFT JOIN public.groups g ON g.id = u.group_id
+    LEFT JOIN public.prospects p ON p.agent_id = u.id AND p.tenant_id = p_tenant_id
+    LEFT JOIN sales s ON s.user_id = u.id
+    WHERE u.tenant_id = p_tenant_id
+      AND u.role IN ('agent', 'group_leader')
+      AND u.status = 'active'
+    GROUP BY u.id, u.name, u.agent_code, u.group_id, g.name
+  ) individual_stats;
+
+  -- Group aggregated stats
+  WITH sales AS (
+    SELECT
+      s.user_id,
+      COALESCE(s.ace,  0)::FLOAT8 AS ace,
+      COALESCE(s.fyc,  0)::FLOAT8 AS fyc,
+      COALESCE(s.fyct, 0)::FLOAT8 AS fyct,
+      COALESCE(s.noc,  0)::FLOAT8 AS noc
+    FROM (
+      SELECT user_id, ace, fyc_mtd AS fyc, fyct_mtd AS fyct, noc
+      FROM   public.sales_report_mtd_fyc
+      WHERE  p_period = 'mtd'
+        AND  tenant_id = p_tenant_id
+        AND  year  = v_year
+        AND  month = v_month
+      UNION ALL
+      SELECT user_id, ace, fyc, fyct, noc FROM (
+        SELECT DISTINCT ON (user_id) user_id, ace, fyc, fyct, noc
+        FROM   public.sales_report_ytd
+        WHERE  p_period = 'ytd'
+          AND  tenant_id = p_tenant_id
+          AND  year = v_year
+        ORDER  BY user_id, month DESC
+      ) ytd_latest
+    ) s
+  ),
+  group_sales AS (
+    SELECT
+      u.group_id,
+      SUM(s.ace)  AS ace,
+      SUM(s.fyc)  AS fyc,
+      SUM(s.fyct) AS fyct,
+      SUM(s.noc)  AS noc
+    FROM   public.users u
+    JOIN   sales s ON s.user_id = u.id
+    WHERE  u.tenant_id = p_tenant_id
+      AND  u.status = 'active'
+      AND  u.role IN ('agent', 'group_leader')
+    GROUP  BY u.group_id
+  )
+  SELECT json_agg(group_stats)
+  INTO v_groups
+  FROM (
+    SELECT
+      g.id AS group_id,
+      g.name AS group_name,
+      leader.name AS leader_name,
+      COUNT(DISTINCT u.id) AS member_count,
+      COUNT(p.id) FILTER (WHERE p.created_at >= p_period_start) AS prospects_added,
+      COUNT(p.id) FILTER (
+        WHERE p.appointment_status = 'done'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS appointments_completed,
+      COUNT(p.id) FILTER (
+        WHERE p.current_stage = 'sales'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_meetings,
+      COUNT(p.id) FILTER (
+        WHERE p.sales_outcome = 'successful'
+        AND COALESCE(p.sales_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_successful,
+      COALESCE((
+        SELECT SUM(pt.points)
+        FROM public.point_transactions pt
+        WHERE pt.tenant_id = p_tenant_id
+          AND pt.created_at >= p_period_start
+          AND pt.user_id IN (
+            SELECT u2.id FROM public.users u2
+            WHERE u2.group_id   = g.id
+              AND u2.tenant_id  = p_tenant_id
+              AND u2.role IN ('agent', 'group_leader')
+              AND u2.status = 'active'
+          )
+      ), 0) AS total_points,
+      COALESCE(MAX(gs.ace),  0) AS ace,
+      COALESCE(MAX(gs.fyc),  0) AS fyc,
+      COALESCE(MAX(gs.fyct), 0) AS fyct,
+      COALESCE(MAX(gs.ace) / NULLIF(MAX(gs.noc), 0), 0) AS acs
+    FROM public.groups g
+    LEFT JOIN public.users leader ON leader.id = g.leader_id AND leader.tenant_id = p_tenant_id
+    JOIN public.users u ON u.group_id = g.id AND u.role IN ('agent', 'group_leader') AND u.tenant_id = p_tenant_id AND u.status = 'active'
+    LEFT JOIN public.prospects p ON p.agent_id = u.id AND p.tenant_id = p_tenant_id
+    LEFT JOIN group_sales gs ON gs.group_id = g.id
+    WHERE g.tenant_id = p_tenant_id
+    GROUP BY g.id, g.name, leader.name
+  ) group_stats;
+
+  RETURN json_build_object(
+    'individual', COALESCE(v_individual, '[]'::json),
+    'groups', COALESCE(v_groups, '[]'::json)
+  );
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER;

--- a/tests/integration/leaderboard.test.ts
+++ b/tests/integration/leaderboard.test.ts
@@ -254,6 +254,7 @@ describe('GET /api/leaderboard/stats — happy path (admin)', () => {
       expect(entry).toHaveProperty('ace');
       expect(entry).toHaveProperty('fyc');
       expect(entry).toHaveProperty('fyct');
+      expect(entry).toHaveProperty('acs');
 
       expect(typeof entry['prospects_added']).toBe('number');
       expect(typeof entry['appointments_completed']).toBe('number');
@@ -263,6 +264,7 @@ describe('GET /api/leaderboard/stats — happy path (admin)', () => {
       expect(typeof entry['ace']).toBe('number');
       expect(typeof entry['fyc']).toBe('number');
       expect(typeof entry['fyct']).toBe('number');
+      expect(typeof entry['acs']).toBe('number');
     }
   });
 
@@ -295,6 +297,7 @@ describe('GET /api/leaderboard/stats — happy path (admin)', () => {
       expect(entry).toHaveProperty('ace');
       expect(entry).toHaveProperty('fyc');
       expect(entry).toHaveProperty('fyct');
+      expect(entry).toHaveProperty('acs');
 
       expect(typeof entry['member_count']).toBe('number');
       expect(typeof entry['prospects_added']).toBe('number');
@@ -305,6 +308,7 @@ describe('GET /api/leaderboard/stats — happy path (admin)', () => {
       expect(typeof entry['ace']).toBe('number');
       expect(typeof entry['fyc']).toBe('number');
       expect(typeof entry['fyct']).toBe('number');
+      expect(typeof entry['acs']).toBe('number');
     }
   });
 });

--- a/tests/unit/leaderboard/leaderboard.service.test.ts
+++ b/tests/unit/leaderboard/leaderboard.service.test.ts
@@ -52,6 +52,7 @@ const mockIndividual: ILeaderboardStatsIndividual[] = [
     ace: 50000.5,
     fyc: 12000,
     fyct: 8000,
+    acs: 16666.833333333332,
   },
   {
     user_id: 'user-uuid-2',
@@ -67,6 +68,7 @@ const mockIndividual: ILeaderboardStatsIndividual[] = [
     ace: 0,
     fyc: 0,
     fyct: 0,
+    acs: 0,
   },
 ];
 
@@ -84,6 +86,7 @@ const mockGroups: ILeaderboardStatsGroup[] = [
     ace: 250000.75,
     fyc: 60000,
     fyct: 40000,
+    acs: 27777.861111111113,
   },
 ];
 
@@ -156,7 +159,7 @@ describe('LeaderboardService.getStats', () => {
     expect(parsed.getUTCHours()).toBe(0);
   });
 
-  it('returns ace, fyc, fyct on individual entries untouched from the RPC response', async () => {
+  it('returns ace, fyc, fyct, acs on individual entries untouched from the RPC response', async () => {
     jest.spyOn(leaderboardRepository, 'getStats').mockResolvedValue({
       data: { individual: mockIndividual, groups: mockGroups },
     } as never);
@@ -167,12 +170,15 @@ describe('LeaderboardService.getStats', () => {
     expect(result.individual[0].ace).toBe(50000.5);
     expect(result.individual[0].fyc).toBe(12000);
     expect(result.individual[0].fyct).toBe(8000);
+    expect(result.individual[0].acs).toBe(16666.833333333332);
     expect(result.individual[1].ace).toBe(0);
     expect(result.individual[1].fyc).toBe(0);
     expect(result.individual[1].fyct).toBe(0);
+    // NOC=0 control row: acs collapses to 0
+    expect(result.individual[1].acs).toBe(0);
   });
 
-  it('returns ace, fyc, fyct on group entries untouched from the RPC response', async () => {
+  it('returns ace, fyc, fyct, acs on group entries untouched from the RPC response', async () => {
     jest.spyOn(leaderboardRepository, 'getStats').mockResolvedValue({
       data: { individual: mockIndividual, groups: mockGroups },
     } as never);
@@ -183,6 +189,7 @@ describe('LeaderboardService.getStats', () => {
     expect(result.groups[0].ace).toBe(250000.75);
     expect(result.groups[0].fyc).toBe(60000);
     expect(result.groups[0].fyct).toBe(40000);
+    expect(result.groups[0].acs).toBe(27777.861111111113);
   });
 
   it('echoes the period back on the response payload', async () => {


### PR DESCRIPTION
## Summary

Completes the leaderboard metric set by adding **ACS (Average Case Size = ACE / NOC)** to `GET /api/leaderboard/stats?period=mtd|ytd`. ACS is returned on every row of both `individual[]` and `groups[]`, alongside the `ace`/`fyc`/`fyct` shipped in #66. Purely additive — no request, param, or envelope changes.

## How it works

- **`noc`** is threaded through the existing `sales` CTE (both MTD and YTD branches) — `sales_report_mtd_fyc.noc` for `mtd`, `sales_report_ytd.noc` (latest month) for `ytd`.
- **Individual**: `acs = MAX(ace) / NULLIF(MAX(noc), 0)` — one sales row per user.
- **Group**: `acs = SUM(ace) / SUM(noc)` via the pre-aggregated `group_sales` CTE (weighted average case size — `MAX(gs.*)` over the single per-group row, so the `users × prospects` join can't corrupt it).
- **NOC = 0 → ACS = 0** (`NULLIF` + `COALESCE`); quotient is raw **FLOAT8** (frontend handles display rounding).
- Same `period` semantics as ACE: `mtd` = current month, `ytd` = latest cumulative snapshot for the year.

Migration is a plain `CREATE OR REPLACE` (signature unchanged from #66) — no DROP.

## Testing

- Unit (`tests/unit/leaderboard/`): `acs` passthrough on individual + group, incl. the NOC=0 → `acs=0` control row.
- Integration (`tests/integration/leaderboard.test.ts`): `acs` presence + numeric-type assertions on both arrays; migration applied locally.
- `npm run type-check` clean; **27/27 leaderboard tests pass**.

## Caveats for consumers

- **Group ACS ≠ mean of member ACS** — it's weighted (`ΣACE/ΣNOC`), so it will legitimately differ from averaging the `individual[]` values. Intentional; most likely to be mistaken for a bug.
- **`acs = 0` means "no cases" (NOC=0)**, not necessarily zero commission — surface accordingly in the UI.
- Inherits ACE/NOC freshness: `mtd` is `0` until the month's ETL lands; `ytd` reflects the latest uploaded month.

## Notes

- `src/types/database.types.ts` unchanged — RPC return is untyped `Json`, signature unchanged; `acs` type-safety rests on the `ILeaderboardStats*` interfaces. Regenerate via `supabase gen types` if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)