### PR TITLE
feat(sales-report): ingest ETL-provided ACS instead of computing it

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5777,10 +5777,11 @@ components:
         acs:
           type: number
           description: >
-            Average Case Size = ACE / NOC for the period. For period=mtd uses
-            the current month's ACE and NOC; for period=ytd uses the latest
-            cumulative snapshot for the current year. Returns 0 when there are
-            no cases (NOC = 0).
+            Average Case Size for the period. For `period=mtd`, the current
+            calendar month's value sourced from `sales_report_mtd`; for
+            `period=ytd`, the latest available month snapshot for the current
+            year from `sales_report_ytd`. Defaults to 0 when no sales-report
+            data is available.
           example: 12500.50
 
     LeaderboardStatsGroupObject:
@@ -6264,10 +6265,11 @@ components:
                 description: >
                   Open-ended bag of column-name → value pairs. Recognised
                   numeric keys include the YTD totals (`'ACE (YTD)'`,
-                  `'NOC (YTD)'`, `'FYCT (YTD)'`, `'% FYCT (YTD)'`,
-                  `'MDRT SHORTAGE FYCT'`, `'FYC (YTD)'`, `'% FYC (YTD)'`,
-                  `'MDRT SHORTAGE FYC'`) and per-month MTD pairs
-                  (`'JANUARY ACE'`, `'JANUARY NOC'`, etc.). String keys
+                  `'NOC (YTD)'`, `'ACS (YTD)'`, `'FYCT (YTD)'`,
+                  `'% FYCT (YTD)'`, `'MDRT SHORTAGE FYCT'`, `'FYC (YTD)'`,
+                  `'% FYC (YTD)'`, `'MDRT SHORTAGE FYC'`) and per-month MTD
+                  groups (`'JANUARY ACE'`, `'JANUARY NOC'`,
+                  `'JANUARY ACS'`, etc.). String keys
                   like `'AGENT CODE'` and `'AGENT NAME'` (which the ETL
                   may include as duplicates of the outer fields) are
                   accepted and ignored. Missing or non-numeric values

--- a/src/services/salesReport.service.ts
+++ b/src/services/salesReport.service.ts
@@ -141,6 +141,7 @@ class SalesReportService {
           month: reportMonth,
           ace: readRowData(r, 'ACE (YTD)'),
           noc: readRowData(r, 'NOC (YTD)'),
+          acs: readRowData(r, 'ACS (YTD)'),
           fyct: readRowData(r, 'FYCT (YTD)'),
           fyct_pct: readRowData(r, '% FYCT (YTD)'),
           mdrt_shortage_fyct: readRowData(r, 'MDRT SHORTAGE FYCT'),
@@ -152,6 +153,7 @@ class SalesReportService {
         for (const [monthName, monthNum] of Object.entries(MONTH_MAP)) {
           const aceKey = `${monthName} ACE`;
           const nocKey = `${monthName} NOC`;
+          const acsKey = `${monthName} ACS`;
           const aceRaw = r[aceKey];
           const nocRaw = r[nocKey];
           if (aceRaw === undefined && nocRaw === undefined) continue;
@@ -164,6 +166,7 @@ class SalesReportService {
             month: monthNum,
             ace: num(aceRaw),
             noc: num(nocRaw),
+            acs: num(r[acsKey]),
           });
         }
       }

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -741,6 +741,7 @@ export type Database = {
       sales_report_mtd: {
         Row: {
           ace: number
+          acs: number
           batch_id: string
           created_at: string
           id: string
@@ -753,6 +754,7 @@ export type Database = {
         }
         Insert: {
           ace?: number
+          acs?: number
           batch_id: string
           created_at?: string
           id?: string
@@ -765,6 +767,7 @@ export type Database = {
         }
         Update: {
           ace?: number
+          acs?: number
           batch_id?: string
           created_at?: string
           id?: string
@@ -802,6 +805,7 @@ export type Database = {
       sales_report_ytd: {
         Row: {
           ace: number
+          acs: number
           batch_id: string
           created_at: string
           fyc: number
@@ -820,6 +824,7 @@ export type Database = {
         }
         Insert: {
           ace?: number
+          acs?: number
           batch_id: string
           created_at?: string
           fyc?: number
@@ -838,6 +843,7 @@ export type Database = {
         }
         Update: {
           ace?: number
+          acs?: number
           batch_id?: string
           created_at?: string
           fyc?: number
@@ -1020,6 +1026,7 @@ export type Database = {
       sales_report_mtd_fyc: {
         Row: {
           ace: number | null
+          acs: number | null
           fyc_mtd: number | null
           fyct_mtd: number | null
           id: string | null

--- a/supabase/migrations/20260609114750_add_acs_columns_to_sales_reports.sql
+++ b/supabase/migrations/20260609114750_add_acs_columns_to_sales_reports.sql
@@ -1,0 +1,31 @@
+-- Store ETL-provided ACS (Average Case Size) directly instead of computing it.
+-- The ETL now emits an `ACS (YTD)` column and per-month `<MONTH> ACS` columns,
+-- so persist the value on both the YTD and MTD sales-report tables.
+-- The MTD FYC view is redefined to surface the stored MTD acs (appended last,
+-- since CREATE OR REPLACE VIEW only permits adding new columns at the tail).
+
+ALTER TABLE sales_report_ytd ADD COLUMN acs NUMERIC(15,4) NOT NULL DEFAULT 0;
+ALTER TABLE sales_report_mtd ADD COLUMN acs NUMERIC(15,4) NOT NULL DEFAULT 0;
+
+CREATE OR REPLACE VIEW sales_report_mtd_fyc AS
+SELECT
+  m.id,
+  m.tenant_id,
+  m.user_id,
+  m.year,
+  m.month,
+  m.ace,
+  m.noc,
+  y.fyc  - LAG(y.fyc,  1, 0) OVER (
+    PARTITION BY y.tenant_id, y.user_id, y.year ORDER BY y.month
+  ) AS fyc_mtd,
+  y.fyct - LAG(y.fyct, 1, 0) OVER (
+    PARTITION BY y.tenant_id, y.user_id, y.year ORDER BY y.month
+  ) AS fyct_mtd,
+  m.acs
+FROM sales_report_mtd m
+JOIN sales_report_ytd y
+  ON  y.tenant_id = m.tenant_id
+  AND y.user_id   = m.user_id
+  AND y.year      = m.year
+  AND y.month     = m.month;

--- a/supabase/migrations/20260609114757_add_etl_acs_to_leaderboard_stats.sql
+++ b/supabase/migrations/20260609114757_add_etl_acs_to_leaderboard_stats.sql
@@ -1,0 +1,185 @@
+-- Switch individual ACS from a computed ACE/NOC quotient to the ETL-provided
+-- stored value. The `sales` CTE now threads the stored `acs` column (from
+-- sales_report_mtd_fyc for MTD and sales_report_ytd for YTD), and individual
+-- ACS becomes COALESCE(MAX(s.acs), 0). NOC is still threaded because GROUP ACS
+-- stays the weighted SUM(ace)/SUM(noc) — group_sales and group_stats unchanged.
+-- Signature is unchanged, so this is a plain CREATE OR REPLACE.
+
+CREATE OR REPLACE FUNCTION get_leaderboard_stats(
+  p_tenant_id    UUID,
+  p_period_start TIMESTAMPTZ,
+  p_period       TEXT DEFAULT 'mtd'
+)
+RETURNS JSON AS $$
+DECLARE
+  v_year       SMALLINT := EXTRACT(YEAR  FROM p_period_start)::SMALLINT;
+  v_month      SMALLINT := EXTRACT(MONTH FROM p_period_start)::SMALLINT;
+  v_individual JSON;
+  v_groups     JSON;
+BEGIN
+  -- Individual stats per agent/group_leader
+  WITH sales AS (
+    SELECT
+      s.user_id,
+      COALESCE(s.ace,  0)::FLOAT8 AS ace,
+      COALESCE(s.fyc,  0)::FLOAT8 AS fyc,
+      COALESCE(s.fyct, 0)::FLOAT8 AS fyct,
+      COALESCE(s.noc,  0)::FLOAT8 AS noc,
+      COALESCE(s.acs,  0)::FLOAT8 AS acs
+    FROM (
+      -- MTD branch
+      SELECT user_id, ace, fyc_mtd AS fyc, fyct_mtd AS fyct, noc, acs
+      FROM   public.sales_report_mtd_fyc
+      WHERE  p_period = 'mtd'
+        AND  tenant_id = p_tenant_id
+        AND  year  = v_year
+        AND  month = v_month
+      UNION ALL
+      -- YTD branch: latest month row per user for the current year
+      SELECT user_id, ace, fyc, fyct, noc, acs FROM (
+        SELECT DISTINCT ON (user_id) user_id, ace, fyc, fyct, noc, acs
+        FROM   public.sales_report_ytd
+        WHERE  p_period = 'ytd'
+          AND  tenant_id = p_tenant_id
+          AND  year = v_year
+        ORDER  BY user_id, month DESC
+      ) ytd_latest
+    ) s
+  )
+  SELECT json_agg(individual_stats)
+  INTO v_individual
+  FROM (
+    SELECT
+      u.id AS user_id,
+      u.name,
+      u.agent_code,
+      u.group_id,
+      g.name AS group_name,
+      COUNT(p.id) FILTER (WHERE p.created_at >= p_period_start) AS prospects_added,
+      COUNT(p.id) FILTER (
+        WHERE p.appointment_status = 'done'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS appointments_completed,
+      COUNT(p.id) FILTER (
+        WHERE p.current_stage = 'sales'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_meetings,
+      COUNT(p.id) FILTER (
+        WHERE p.sales_outcome = 'successful'
+        AND COALESCE(p.sales_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_successful,
+      COALESCE((
+        SELECT SUM(pt.points)
+        FROM public.point_transactions pt
+        WHERE pt.user_id   = u.id
+          AND pt.tenant_id = p_tenant_id
+          AND pt.created_at >= p_period_start
+      ), 0) AS total_points,
+      COALESCE(MAX(s.ace),  0) AS ace,
+      COALESCE(MAX(s.fyc),  0) AS fyc,
+      COALESCE(MAX(s.fyct), 0) AS fyct,
+      COALESCE(MAX(s.acs), 0) AS acs
+    FROM public.users u
+    LEFT JOIN public.groups g ON g.id = u.group_id
+    LEFT JOIN public.prospects p ON p.agent_id = u.id AND p.tenant_id = p_tenant_id
+    LEFT JOIN sales s ON s.user_id = u.id
+    WHERE u.tenant_id = p_tenant_id
+      AND u.role IN ('agent', 'group_leader')
+      AND u.status = 'active'
+    GROUP BY u.id, u.name, u.agent_code, u.group_id, g.name
+  ) individual_stats;
+
+  -- Group aggregated stats
+  WITH sales AS (
+    SELECT
+      s.user_id,
+      COALESCE(s.ace,  0)::FLOAT8 AS ace,
+      COALESCE(s.fyc,  0)::FLOAT8 AS fyc,
+      COALESCE(s.fyct, 0)::FLOAT8 AS fyct,
+      COALESCE(s.noc,  0)::FLOAT8 AS noc,
+      COALESCE(s.acs,  0)::FLOAT8 AS acs
+    FROM (
+      SELECT user_id, ace, fyc_mtd AS fyc, fyct_mtd AS fyct, noc, acs
+      FROM   public.sales_report_mtd_fyc
+      WHERE  p_period = 'mtd'
+        AND  tenant_id = p_tenant_id
+        AND  year  = v_year
+        AND  month = v_month
+      UNION ALL
+      SELECT user_id, ace, fyc, fyct, noc, acs FROM (
+        SELECT DISTINCT ON (user_id) user_id, ace, fyc, fyct, noc, acs
+        FROM   public.sales_report_ytd
+        WHERE  p_period = 'ytd'
+          AND  tenant_id = p_tenant_id
+          AND  year = v_year
+        ORDER  BY user_id, month DESC
+      ) ytd_latest
+    ) s
+  ),
+  group_sales AS (
+    SELECT
+      u.group_id,
+      SUM(s.ace)  AS ace,
+      SUM(s.fyc)  AS fyc,
+      SUM(s.fyct) AS fyct,
+      SUM(s.noc)  AS noc
+    FROM   public.users u
+    JOIN   sales s ON s.user_id = u.id
+    WHERE  u.tenant_id = p_tenant_id
+      AND  u.status = 'active'
+      AND  u.role IN ('agent', 'group_leader')
+    GROUP  BY u.group_id
+  )
+  SELECT json_agg(group_stats)
+  INTO v_groups
+  FROM (
+    SELECT
+      g.id AS group_id,
+      g.name AS group_name,
+      leader.name AS leader_name,
+      COUNT(DISTINCT u.id) AS member_count,
+      COUNT(p.id) FILTER (WHERE p.created_at >= p_period_start) AS prospects_added,
+      COUNT(p.id) FILTER (
+        WHERE p.appointment_status = 'done'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS appointments_completed,
+      COUNT(p.id) FILTER (
+        WHERE p.current_stage = 'sales'
+        AND COALESCE(p.appointment_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_meetings,
+      COUNT(p.id) FILTER (
+        WHERE p.sales_outcome = 'successful'
+        AND COALESCE(p.sales_completed_at, p.updated_at) >= p_period_start
+      ) AS sales_successful,
+      COALESCE((
+        SELECT SUM(pt.points)
+        FROM public.point_transactions pt
+        WHERE pt.tenant_id = p_tenant_id
+          AND pt.created_at >= p_period_start
+          AND pt.user_id IN (
+            SELECT u2.id FROM public.users u2
+            WHERE u2.group_id   = g.id
+              AND u2.tenant_id  = p_tenant_id
+              AND u2.role IN ('agent', 'group_leader')
+              AND u2.status = 'active'
+          )
+      ), 0) AS total_points,
+      COALESCE(MAX(gs.ace),  0) AS ace,
+      COALESCE(MAX(gs.fyc),  0) AS fyc,
+      COALESCE(MAX(gs.fyct), 0) AS fyct,
+      COALESCE(MAX(gs.ace) / NULLIF(MAX(gs.noc), 0), 0) AS acs
+    FROM public.groups g
+    LEFT JOIN public.users leader ON leader.id = g.leader_id AND leader.tenant_id = p_tenant_id
+    JOIN public.users u ON u.group_id = g.id AND u.role IN ('agent', 'group_leader') AND u.tenant_id = p_tenant_id AND u.status = 'active'
+    LEFT JOIN public.prospects p ON p.agent_id = u.id AND p.tenant_id = p_tenant_id
+    LEFT JOIN group_sales gs ON gs.group_id = g.id
+    WHERE g.tenant_id = p_tenant_id
+    GROUP BY g.id, g.name, leader.name
+  ) group_stats;
+
+  RETURN json_build_object(
+    'individual', COALESCE(v_individual, '[]'::json),
+    'groups', COALESCE(v_groups, '[]'::json)
+  );
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER;

--- a/tests/unit/sales-report/salesReport.service.upload.test.ts
+++ b/tests/unit/sales-report/salesReport.service.upload.test.ts
@@ -44,17 +44,17 @@ const baseEtl: IEtlResult = {
     {
       agentCode: 'A1',
       rowData: {
-        'ACE (YTD)': 100, 'NOC (YTD)': 5, 'FYCT (YTD)': 80, '% FYCT (YTD)': 0.4,
+        'ACE (YTD)': 100, 'NOC (YTD)': 5, 'ACS (YTD)': 20, 'FYCT (YTD)': 80, '% FYCT (YTD)': 0.4,
         'MDRT SHORTAGE FYCT': 20, 'FYC (YTD)': 70, '% FYC (YTD)': 0.35,
         'MDRT SHORTAGE FYC': 30,
-        'JANUARY ACE': 10, 'JANUARY NOC': 1,
-        'MAY ACE': 30, 'MAY NOC': 2,
+        'JANUARY ACE': 10, 'JANUARY NOC': 1, 'JANUARY ACS': 10,
+        'MAY ACE': 30, 'MAY NOC': 2, 'MAY ACS': 15,
       },
     },
     {
       agentCode: 'A2',
       rowData: {
-        'ACE (YTD)': 200, 'NOC (YTD)': 10, 'FYCT (YTD)': 160, '% FYCT (YTD)': 0.4,
+        'ACE (YTD)': 200, 'NOC (YTD)': 10, 'ACS (YTD)': 20, 'FYCT (YTD)': 160, '% FYCT (YTD)': 0.4,
         'MDRT SHORTAGE FYCT': 40, 'FYC (YTD)': 140, '% FYC (YTD)': 0.35,
         'MDRT SHORTAGE FYC': 60,
       },
@@ -94,13 +94,19 @@ describe('SalesReportService.uploadReport — happy path', () => {
     const ytdRows = (salesReportYtdRepository.bulkUpsert as jest.Mock).mock.calls[0][0];
     expect(ytdRows).toHaveLength(2);
     expect(ytdRows[0]).toMatchObject({
-      tenant_id: 't1', user_id: 'u1', year: 2026, month: 5, ace: 100, fyc: 70,
+      tenant_id: 't1', user_id: 'u1', year: 2026, month: 5, ace: 100, fyc: 70, acs: 20,
     });
+    // YTD acs is read from the 'ACS (YTD)' column, not derived from ace/noc.
+    expect(ytdRows[0].acs).toBe(20);
+    expect(ytdRows[1].acs).toBe(20);
 
     expect(salesReportMtdRepository.bulkUpsert).toHaveBeenCalledTimes(1);
     const mtdRows = (salesReportMtdRepository.bulkUpsert as jest.Mock).mock.calls[0][0];
     // A1 has JANUARY + MAY MTD; A2 has none → total = 2
     expect(mtdRows).toHaveLength(2);
+    // Each per-month MTD row reads acs from its '<MONTH> ACS' column.
+    expect(mtdRows[0]).toMatchObject({ month: 1, ace: 10, noc: 1, acs: 10 });
+    expect(mtdRows[1]).toMatchObject({ month: 5, ace: 30, noc: 2, acs: 15 });
 
     expect(uploadBatchRepository.updateBatchSummary).toHaveBeenCalledWith('batch-1', {
       rows_loaded: 2,
@@ -216,9 +222,12 @@ describe('SalesReportService.uploadReport — coercion of mixed rowData values',
           // Numeric values as strings (defensive coercion)
           'ACE (YTD)': '100.5' as unknown as number,
           'NOC (YTD)': null as unknown as number,
+          // YTD acs entirely absent → must default to 0.
           'FYC (YTD)': 70,
           'JANUARY ACE': '15' as unknown as number,
           'JANUARY NOC': 1,
+          // MTD acs is a non-numeric string → must coerce to 0.
+          'JANUARY ACS': 'n/a' as unknown as number,
         },
       }],
     };
@@ -231,12 +240,14 @@ describe('SalesReportService.uploadReport — coercion of mixed rowData values',
     const ytdRow = (salesReportYtdRepository.bulkUpsert as jest.Mock).mock.calls[0][0][0];
     expect(ytdRow.ace).toBe(100.5);  // string coerced
     expect(ytdRow.noc).toBe(0);      // null → 0
+    expect(ytdRow.acs).toBe(0);      // 'ACS (YTD)' absent → 0
     expect(ytdRow.fyc).toBe(70);
 
     const mtdRow = (salesReportMtdRepository.bulkUpsert as jest.Mock).mock.calls[0][0][0];
     expect(mtdRow.month).toBe(1);
     expect(mtdRow.ace).toBe(15);
     expect(mtdRow.noc).toBe(1);
+    expect(mtdRow.acs).toBe(0);      // non-numeric 'JANUARY ACS' → 0
   });
 });
 


### PR DESCRIPTION
## Summary

The ETL pipeline now emits **ACS (Average Case Size)** directly — `ACS (YTD)` plus per-month `<MONTH> ACS` columns. This PR stops the backend from computing ACS as `ACE / NOC` and instead **persists and reads the ETL-provided value**.

- **Store it**: new `acs` column on `sales_report_ytd` and `sales_report_mtd` (and surfaced on the `sales_report_mtd_fyc` view). Ingest (`POST /api/reports/ingest`) reads `ACS (YTD)` into the YTD row and each `<MONTH> ACS` into the MTD rows, using the existing `readRowData`/`num` coercion (missing/non-numeric → 0).
- **Read it**: `get_leaderboard_stats` now returns the **individual** `acs` from the stored value (`MAX(s.acs)`) threaded through the `sales` CTE, replacing the ACE/NOC quotient.
- **Group ACS unchanged**: stays the weighted `SUM(ace)/SUM(noc)`, since the ETL provides no per-group value. The `GET /api/leaderboard/stats` response shape is unchanged (`acs` already shipped in #67).

## Changes

| Area | Detail |
|---|---|
| Migration A | `20260609114750_add_acs_columns_to_sales_reports.sql` — `acs NUMERIC(15,4) NOT NULL DEFAULT 0` on both tables; `CREATE OR REPLACE VIEW` appends `m.acs` to the MTD FYC view (tail-append, as required). |
| Migration B | `20260609114757_add_etl_acs_to_leaderboard_stats.sql` — individual acs reads stored value; group acs untouched; function signature and all other metrics byte-for-byte unchanged. |
| Service | `salesReport.service.ts` — ingest reads `ACS (YTD)` / `<MONTH> ACS`. |
| Types | `database.types.ts` regenerated; `acs` on both tables + the view. |
| Docs | `openapi.yaml` — ingest `rowData` column list gains `ACS (YTD)` / `JANUARY ACS`; individual-acs description updated to reflect it is now sourced from the sales-report tables (no longer `ACE / NOC`). |

## Testing

- Unit/service: **26/26 passing** — added ingest assertions for YTD/MTD acs reads + a 0-coercion control; leaderboard passthrough tests stay green.
- `npm run type-check`: exit 0. No `eslint-disable`.
- Manual verification: ingested a 6-record sample (`processed: 6, skipped: 0`); confirmed `sales_report_ytd.acs` / `sales_report_mtd.acs` store the ETL values verbatim (e.g. agent → `ACS (YTD)` 691.02, `MAY ACS` 1391.22).
- Integration suite (live Supabase) not run in this environment.

## Notes / caveats

- The new `acs` column defaults to `0` for any batch ingested **before** this change — backfill (re-ingest) is out of scope.
- Group `acs` description in OpenAPI intentionally left as `= ACE / NOC`: still accurate for the weighted group aggregation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)