### PR TITLE
feat(taxonomies): tenant-configurable taxonomy (dropdown) API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -32,6 +32,8 @@ tags:
     description: Gamification agent points endpoints
   - name: Agent Codes
     description: Tenant-scoped agent code provisioning endpoints
+  - name: Taxonomies
+    description: Tenant-configurable lookup values for dropdowns, grouped by type
   - name: Coaching Sessions
     description: Coaching session management and attendance endpoints
   - name: Sales Reports
@@ -3761,6 +3763,426 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
 
   ##############################################################################
+  # TAXONOMIES
+  ##############################################################################
+
+  /taxonomies:
+    get:
+      tags: [Taxonomies]
+      summary: List taxonomy values
+      description: >
+        Returns the taxonomy lookup values provisioned for the authenticated
+        user's tenant, ordered by `sort_order` ascending and then `value`
+        ascending. The tenant is derived from the JWT — clients cannot specify
+        it. All authenticated roles may access this endpoint.
+
+
+        The optional `type` query parameter filters the result to a single
+        category (e.g. `lead_source`). When provided it must be a non-empty
+        string; omit it to return every taxonomy value for the tenant.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+            minLength: 1
+          description: >
+            When provided, filters taxonomy values to the given category. Must
+            be a non-empty string; an empty value returns 400.
+      responses:
+        '200':
+          description: Taxonomy values retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, data]
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TaxonomyObject'
+              example:
+                success: true
+                data:
+                  - id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                    tenant_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+                    type: lead_source
+                    value: Referral
+                    sort_order: 0
+                    created_at: '2026-06-01T08:00:00.000Z'
+                    updated_at: '2026-06-01T08:00:00.000Z'
+                  - id: b2c3d4e5-f6a7-8901-bcde-f12345678901
+                    tenant_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+                    type: lead_source
+                    value: Walk-in
+                    sort_order: 1
+                    created_at: '2026-06-01T08:00:00.000Z'
+                    updated_at: '2026-06-01T08:00:00.000Z'
+        '400':
+          description: >
+            Bad request. Returned when the `type` query parameter is present but
+            is an empty string.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                message: Validation failed
+                errors:
+                  - code: too_small
+                    minimum: 1
+                    type: string
+                    inclusive: true
+                    exact: false
+                    message: String must contain at least 1 character(s)
+                    path:
+                      - type
+        '401':
+          description: >
+            Unauthorized. Returned when the `Authorization` header is absent,
+            malformed, or contains an invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Unauthorized
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    post:
+      tags: [Taxonomies]
+      summary: Create a taxonomy value (admin only)
+      description: >
+        Creates a new taxonomy lookup value under the authenticated user's
+        tenant. The caller must supply a valid Bearer token belonging to a user
+        with the `admin` role; any other role returns 403. The tenant is derived
+        from the JWT — clients cannot specify it.
+
+
+        The combination of `(tenant_id, type, value)` must be unique within the
+        tenant — submitting a duplicate returns 409.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [type, value]
+              properties:
+                type:
+                  type: string
+                  minLength: 1
+                  description: >
+                    The taxonomy category this value belongs to (e.g.
+                    `lead_source`). Required; must be a non-empty string.
+                  example: lead_source
+                value:
+                  type: string
+                  minLength: 1
+                  description: >
+                    The dropdown value to store. Required; must be a non-empty
+                    string.
+                  example: Referral
+                sort_order:
+                  type: integer
+                  default: 0
+                  description: >
+                    Sort position used when ordering values within a category.
+                    Optional; defaults to 0 when omitted.
+                  example: 0
+            example:
+              type: lead_source
+              value: Referral
+              sort_order: 0
+      responses:
+        '201':
+          description: Taxonomy value created successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, data]
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/TaxonomyObject'
+              example:
+                success: true
+                data:
+                  id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                  tenant_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+                  type: lead_source
+                  value: Referral
+                  sort_order: 0
+                  created_at: '2026-06-01T08:00:00.000Z'
+                  updated_at: '2026-06-01T08:00:00.000Z'
+        '400':
+          description: >
+            Bad request. Returned when the request body fails Zod validation —
+            e.g. `type` or `value` missing or empty, `sort_order` not an
+            integer, or an unknown top-level field is present.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                message: Validation failed
+                errors:
+                  - code: too_small
+                    minimum: 1
+                    type: string
+                    inclusive: true
+                    exact: false
+                    message: String must contain at least 1 character(s)
+                    path:
+                      - value
+        '401':
+          description: >
+            Unauthorized. Returned when the `Authorization` header is absent,
+            malformed, or contains an invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Unauthorized
+        '403':
+          description: Forbidden. Returned when the authenticated user is not an admin.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Forbidden
+        '409':
+          description: >
+            Conflict. Returned when a taxonomy value with the same
+            `(type, value)` already exists in the caller's tenant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: A taxonomy value with this type already exists
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /taxonomies/{id}:
+    put:
+      tags: [Taxonomies]
+      summary: Update a taxonomy value (admin only)
+      description: >
+        Updates the `value` and/or `sort_order` of an existing taxonomy value
+        within the authenticated user's tenant. The caller must supply a valid
+        Bearer token belonging to a user with the `admin` role; any other role
+        returns 403. The tenant is derived from the JWT — clients cannot specify
+        it.
+
+
+        At least one of `value` or `sort_order` must be supplied; an empty body
+        returns 400. Returns 404 if no taxonomy value with the given `id` exists
+        in the tenant. Returns 409 if the new `value` collides with an existing
+        `(type, value)` pair in the tenant.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: UUID of the taxonomy value to update.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              minProperties: 1
+              description: >
+                At least one of `value` or `sort_order` must be provided.
+              properties:
+                value:
+                  type: string
+                  minLength: 1
+                  description: New dropdown value. Must be a non-empty string when provided.
+                  example: Referral (updated)
+                sort_order:
+                  type: integer
+                  description: New sort position within the category.
+                  example: 5
+            example:
+              value: Referral (updated)
+              sort_order: 5
+      responses:
+        '200':
+          description: Taxonomy value updated successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, data]
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/TaxonomyObject'
+              example:
+                success: true
+                data:
+                  id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                  tenant_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+                  type: lead_source
+                  value: Referral (updated)
+                  sort_order: 5
+                  created_at: '2026-06-01T08:00:00.000Z'
+                  updated_at: '2026-06-02T09:30:00.000Z'
+        '400':
+          description: >
+            Bad request. Returned when the request body fails Zod validation —
+            e.g. an empty body, neither `value` nor `sort_order` provided, an
+            empty `value`, `sort_order` not an integer, or an unknown top-level
+            field is present.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationErrorResponse'
+              example:
+                message: Validation failed
+                errors:
+                  - code: custom
+                    message: At least one of value or sort_order must be provided
+                    path: []
+        '401':
+          description: >
+            Unauthorized. Returned when the `Authorization` header is absent,
+            malformed, or contains an invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Unauthorized
+        '403':
+          description: Forbidden. Returned when the authenticated user is not an admin.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Forbidden
+        '404':
+          description: >
+            Not found. Returned when no taxonomy value matching the `id` path
+            parameter exists in the caller's tenant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Taxonomy not found
+        '409':
+          description: >
+            Conflict. Returned when the new `value` collides with an existing
+            `(type, value)` pair in the caller's tenant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: A taxonomy value with this type already exists
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+    delete:
+      tags: [Taxonomies]
+      summary: Delete a taxonomy value (admin only)
+      description: >
+        Deletes an existing taxonomy value within the authenticated user's
+        tenant. The caller must supply a valid Bearer token belonging to a user
+        with the `admin` role; any other role returns 403. The tenant is derived
+        from the JWT — clients cannot specify it.
+
+
+        Returns 404 if no taxonomy value with the given `id` exists in the
+        tenant. On success the endpoint returns 204 with no response body.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: UUID of the taxonomy value to delete.
+      responses:
+        '204':
+          description: Taxonomy value deleted successfully. No response body.
+        '401':
+          description: >
+            Unauthorized. Returned when the `Authorization` header is absent,
+            malformed, or contains an invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Unauthorized
+        '403':
+          description: Forbidden. Returned when the authenticated user is not an admin.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Forbidden
+        '404':
+          description: >
+            Not found. Returned when no taxonomy value matching the `id` path
+            parameter exists in the caller's tenant.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Taxonomy not found
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  ##############################################################################
   # COACHING SESSIONS
   ##############################################################################
 
@@ -5039,6 +5461,46 @@ components:
           format: date-time
           description: ISO 8601 datetime the row was last modified.
           example: '2025-01-01T00:00:00.000Z'
+
+    TaxonomyObject:
+      type: object
+      required:
+        - id
+        - tenant_id
+        - type
+        - value
+        - sort_order
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+        tenant_id:
+          type: string
+          format: uuid
+          example: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+        type:
+          type: string
+          description: The taxonomy category this value belongs to.
+          example: lead_source
+        value:
+          type: string
+          description: The dropdown value stored for the category.
+          example: Referral
+        sort_order:
+          type: integer
+          description: Sort position used when ordering values within a category.
+          example: 0
+        created_at:
+          type: string
+          format: date-time
+          example: '2026-06-01T08:00:00.000Z'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2026-06-01T08:00:00.000Z'
 
     GroupObject:
       type: object

--- a/src/controllers/taxonomy.controller.ts
+++ b/src/controllers/taxonomy.controller.ts
@@ -1,0 +1,216 @@
+import { NextFunction, Response } from 'express';
+import { z } from 'zod';
+
+import {
+  TaxonomyConflictError,
+  TaxonomyNotFoundError,
+} from '@src/models/errors/taxonomy.errors';
+import { RouteError } from '@src/models/errors/route.error';
+import { IBaseReq, IBaseRes } from '@src/models/interfaces/base.interface';
+import taxonomyService from '@src/services/taxonomy.service';
+import { ITaxonomy } from '@src/types/taxonomy.types';
+import { handleControllerError } from '@src/utils/errorHandlers';
+import HttpStatusCodes from '@src/utils/HttpStatusCodes';
+
+/******************************************************************************
+                            Interfaces
+******************************************************************************/
+
+export interface ICreateTaxonomyReq extends IBaseReq {
+  body: {
+    type: string;
+    value: string;
+    sort_order?: number;
+  };
+}
+
+export interface IUpdateTaxonomyReq extends IBaseReq {
+  params: {
+    id: string;
+  };
+  body: {
+    value?: string;
+    sort_order?: number;
+  };
+}
+
+export interface IDeleteTaxonomyReq extends IBaseReq {
+  params: {
+    id: string;
+  };
+}
+
+export interface IGetTaxonomiesRes extends IBaseRes {
+  success: boolean;
+  data: ITaxonomy[];
+}
+
+export interface ICreateTaxonomyRes extends IBaseRes {
+  success: boolean;
+  data: ITaxonomy;
+}
+
+export interface IUpdateTaxonomyRes extends IBaseRes {
+  success: boolean;
+  data: ITaxonomy;
+}
+
+const getTaxonomiesQuerySchema = z.object({
+  type: z.string().min(1).optional(),
+});
+
+/******************************************************************************
+                            TaxonomyController
+******************************************************************************/
+
+class TaxonomyController {
+  async getAll(
+    req: IBaseReq,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const parsed = getTaxonomiesQuerySchema.safeParse(req.query);
+      if (!parsed.success) {
+        res.status(HttpStatusCodes.BAD_REQUEST).json({
+          message: 'Validation failed',
+          errors: parsed.error.issues,
+        });
+        return;
+      }
+
+      const token = req.headers['authorization']!.slice(7);
+
+      const data = await taxonomyService.getTaxonomies({
+        tenantId: req.user!.tenant_id,
+        type: parsed.data.type,
+        token,
+      });
+
+      const responseBody: IGetTaxonomiesRes = {
+        success: true,
+        data,
+      };
+
+      res.status(HttpStatusCodes.OK).json(responseBody);
+    } catch (error) {
+      return handleControllerError('TaxonomyController.getAll', error, next);
+    }
+  }
+
+  async create(
+    req: ICreateTaxonomyReq,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      if (req.user!.role !== 'admin') {
+        next(new RouteError(HttpStatusCodes.FORBIDDEN, 'Forbidden'));
+        return;
+      }
+
+      const token = req.headers['authorization']!.slice(7);
+      const { type, value, sort_order } = req.body;
+
+      const data = await taxonomyService.createTaxonomy({
+        tenantId: req.user!.tenant_id,
+        type,
+        value,
+        sortOrder: sort_order,
+        token,
+      });
+
+      const responseBody: ICreateTaxonomyRes = {
+        success: true,
+        data,
+      };
+
+      res.status(HttpStatusCodes.CREATED).json(responseBody);
+    } catch (error) {
+      if (error instanceof TaxonomyConflictError) {
+        next(new RouteError(HttpStatusCodes.CONFLICT, error.message));
+        return;
+      }
+      return handleControllerError('TaxonomyController.create', error, next);
+    }
+  }
+
+  async update(
+    req: IUpdateTaxonomyReq,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      if (req.user!.role !== 'admin') {
+        next(new RouteError(HttpStatusCodes.FORBIDDEN, 'Forbidden'));
+        return;
+      }
+
+      const token = req.headers['authorization']!.slice(7);
+      const { id } = req.params;
+      const { value, sort_order } = req.body;
+
+      const data = await taxonomyService.updateTaxonomy({
+        id,
+        tenantId: req.user!.tenant_id,
+        value,
+        sortOrder: sort_order,
+        token,
+      });
+
+      const responseBody: IUpdateTaxonomyRes = {
+        success: true,
+        data,
+      };
+
+      res.status(HttpStatusCodes.OK).json(responseBody);
+    } catch (error) {
+      if (error instanceof TaxonomyNotFoundError) {
+        next(new RouteError(HttpStatusCodes.NOT_FOUND, error.message));
+        return;
+      }
+      if (error instanceof TaxonomyConflictError) {
+        next(new RouteError(HttpStatusCodes.CONFLICT, error.message));
+        return;
+      }
+      return handleControllerError('TaxonomyController.update', error, next);
+    }
+  }
+
+  async delete(
+    req: IDeleteTaxonomyReq,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      if (req.user!.role !== 'admin') {
+        next(new RouteError(HttpStatusCodes.FORBIDDEN, 'Forbidden'));
+        return;
+      }
+
+      const token = req.headers['authorization']!.slice(7);
+      const { id } = req.params;
+
+      await taxonomyService.deleteTaxonomy({
+        id,
+        tenantId: req.user!.tenant_id,
+        token,
+      });
+
+      res.status(HttpStatusCodes.NO_CONTENT).send();
+    } catch (error) {
+      if (error instanceof TaxonomyNotFoundError) {
+        next(new RouteError(HttpStatusCodes.NOT_FOUND, error.message));
+        return;
+      }
+      return handleControllerError('TaxonomyController.delete', error, next);
+    }
+  }
+}
+
+/******************************************************************************
+                                Export
+******************************************************************************/
+
+export const taxonomyController = new TaxonomyController();
+export default taxonomyController;

--- a/src/models/errors/taxonomy.errors.ts
+++ b/src/models/errors/taxonomy.errors.ts
@@ -1,0 +1,13 @@
+export class TaxonomyNotFoundError extends Error {
+  constructor(message = 'Taxonomy not found') {
+    super(message);
+    this.name = 'TaxonomyNotFoundError';
+  }
+}
+
+export class TaxonomyConflictError extends Error {
+  constructor(message = 'A taxonomy value with this type already exists') {
+    super(message);
+    this.name = 'TaxonomyConflictError';
+  }
+}

--- a/src/repositories/taxonomy.repository.ts
+++ b/src/repositories/taxonomy.repository.ts
@@ -1,0 +1,150 @@
+import {
+  TaxonomyConflictError,
+  TaxonomyNotFoundError,
+} from '@src/models/errors/taxonomy.errors';
+import supabaseService from '@src/services/supabase.service';
+import { Database } from '@src/types/database.types';
+import { ITaxonomy } from '@src/types/taxonomy.types';
+import { handleRepositoryError } from '@src/utils/errorHandlers';
+
+type TaxonomiesRow = Database['public']['Tables']['taxonomies']['Row'];
+type TaxonomiesInsert = Database['public']['Tables']['taxonomies']['Insert'];
+type TaxonomiesUpdate = Database['public']['Tables']['taxonomies']['Update'];
+
+const UNIQUE_VIOLATION_CODE = '23505';
+
+/******************************************************************************
+                            TaxonomyRepository
+******************************************************************************/
+
+class TaxonomyRepository {
+  private mapRowToTaxonomy(row: TaxonomiesRow): ITaxonomy {
+    return {
+      id: row.id,
+      tenant_id: row.tenant_id,
+      type: row.type,
+      value: row.value,
+      sort_order: row.sort_order,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+    };
+  }
+
+  async findByTenant(
+    userToken: string,
+    filters: { tenant_id: string; type?: string },
+  ): Promise<ITaxonomy[]> {
+    try {
+      const response = await supabaseService.userSelect(
+        userToken,
+        'taxonomies',
+        '*',
+        filters,
+      );
+
+      if (response.error) {
+        throw new Error(response.error.message);
+      }
+
+      const rows = (response.data ?? []) as unknown as TaxonomiesRow[];
+      return rows.map((row) => this.mapRowToTaxonomy(row));
+    } catch (error) {
+      return handleRepositoryError('TaxonomyRepository.findByTenant', error);
+    }
+  }
+
+  async insert(
+    userToken: string,
+    data: TaxonomiesInsert,
+  ): Promise<ITaxonomy> {
+    try {
+      const response = await supabaseService.userInsert(
+        userToken,
+        'taxonomies',
+        data,
+      );
+
+      if (response.error) {
+        if (
+          (response.error as { code?: string }).code === UNIQUE_VIOLATION_CODE
+        ) {
+          throw new TaxonomyConflictError();
+        }
+        throw new Error(response.error.message);
+      }
+
+      if (!response.data || response.data.length === 0) {
+        throw new Error('No taxonomy returned after insert');
+      }
+
+      const row = response.data[0] as unknown as TaxonomiesRow;
+      return this.mapRowToTaxonomy(row);
+    } catch (error) {
+      return handleRepositoryError('TaxonomyRepository.insert', error);
+    }
+  }
+
+  async update(
+    userToken: string,
+    filters: { id: string; tenant_id: string },
+    values: TaxonomiesUpdate,
+  ): Promise<ITaxonomy> {
+    try {
+      const response = await supabaseService.userUpdate(
+        userToken,
+        'taxonomies',
+        values,
+        filters,
+      );
+
+      if (response.error) {
+        if (
+          (response.error as { code?: string }).code === UNIQUE_VIOLATION_CODE
+        ) {
+          throw new TaxonomyConflictError();
+        }
+        throw new Error(response.error.message);
+      }
+
+      const rows = (response.data ?? []) as unknown as TaxonomiesRow[];
+      if (rows.length === 0) {
+        throw new TaxonomyNotFoundError();
+      }
+
+      return this.mapRowToTaxonomy(rows[0]);
+    } catch (error) {
+      return handleRepositoryError('TaxonomyRepository.update', error);
+    }
+  }
+
+  async remove(
+    userToken: string,
+    filters: { id: string; tenant_id: string },
+  ): Promise<void> {
+    try {
+      const response = await supabaseService.userDelete(
+        userToken,
+        'taxonomies',
+        filters,
+      );
+
+      if (response.error) {
+        throw new Error(response.error.message);
+      }
+
+      const rows = (response.data ?? []) as unknown as TaxonomiesRow[];
+      if (rows.length === 0) {
+        throw new TaxonomyNotFoundError();
+      }
+    } catch (error) {
+      return handleRepositoryError('TaxonomyRepository.remove', error);
+    }
+  }
+}
+
+/******************************************************************************
+                                Export
+******************************************************************************/
+
+export const taxonomyRepository = new TaxonomyRepository();
+export default taxonomyRepository;

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -16,6 +16,7 @@ import prospectRoutes from '@src/routes/prospect.routes';
 import reportJobRoutes from '@src/routes/reportJob.routes';
 import salesReportRoutes from '@src/routes/salesReport.routes';
 import salesReportReadRoutes from '@src/routes/salesReportRead.routes';
+import taxonomyRoutes from '@src/routes/taxonomy.routes';
 import userRoutes from '@src/routes/user.routes';
 
 const router = express.Router();
@@ -36,6 +37,7 @@ router.use('/coaching-sessions', coachingSessionRoutes);
 router.use('/dashboard', dashboardRoutes);
 router.use('/point-activity-types', pointActivityTypeRoutes);
 router.use('/point-configs', pointConfigRoutes);
+router.use('/taxonomies', taxonomyRoutes);
 router.use('/leaderboard', leaderboardRoutes);
 router.use('/agent-points', agentPointsRoutes);
 router.use('/agent-codes', agentCodeRoutes);

--- a/src/routes/taxonomy.routes.ts
+++ b/src/routes/taxonomy.routes.ts
@@ -1,0 +1,71 @@
+import express from 'express';
+import { z } from 'zod';
+
+import taxonomyController, {
+  ICreateTaxonomyReq,
+  IDeleteTaxonomyReq,
+  IUpdateTaxonomyReq,
+} from '@src/controllers/taxonomy.controller';
+import { authenticate } from '@src/middleware/auth';
+import { validate } from '@src/middleware/validate';
+import { IBaseReq } from '@src/models/interfaces/base.interface';
+
+/******************************************************************************
+                            Zod Schemas
+******************************************************************************/
+
+export const createTaxonomySchema = z
+  .object({
+    type: z.string().min(1),
+    value: z.string().min(1),
+    sort_order: z.number().int().optional(),
+  })
+  .strict();
+
+export const updateTaxonomySchema = z
+  .object({
+    value: z.string().min(1).optional(),
+    sort_order: z.number().int().optional(),
+  })
+  .strict()
+  .refine((d) => d.value !== undefined || d.sort_order !== undefined, {
+    message: 'At least one of value or sort_order must be provided',
+  });
+
+/******************************************************************************
+                            Router
+******************************************************************************/
+
+const router = express.Router();
+
+router.get(
+  '/',
+  authenticate,
+  (req, res, next) =>
+    taxonomyController.getAll(req as unknown as IBaseReq, res, next),
+);
+
+router.post(
+  '/',
+  authenticate,
+  validate(createTaxonomySchema),
+  (req, res, next) =>
+    taxonomyController.create(req as unknown as ICreateTaxonomyReq, res, next),
+);
+
+router.put(
+  '/:id',
+  authenticate,
+  validate(updateTaxonomySchema),
+  (req, res, next) =>
+    taxonomyController.update(req as unknown as IUpdateTaxonomyReq, res, next),
+);
+
+router.delete(
+  '/:id',
+  authenticate,
+  (req, res, next) =>
+    taxonomyController.delete(req as unknown as IDeleteTaxonomyReq, res, next),
+);
+
+export default router;

--- a/src/services/taxonomy.service.ts
+++ b/src/services/taxonomy.service.ts
@@ -1,0 +1,155 @@
+import {
+  TaxonomyConflictError,
+  TaxonomyNotFoundError,
+} from '@src/models/errors/taxonomy.errors';
+import taxonomyRepository from '@src/repositories/taxonomy.repository';
+import { Database } from '@src/types/database.types';
+import { ITaxonomy } from '@src/types/taxonomy.types';
+import { handleServiceError } from '@src/utils/errorHandlers';
+import loggingService from '@src/services/logging.service';
+import { getRootCause } from '@src/utils/sentry.utils';
+
+type TaxonomiesUpdate = Database['public']['Tables']['taxonomies']['Update'];
+
+/******************************************************************************
+                            Interfaces
+******************************************************************************/
+
+interface IGetTaxonomiesParams {
+  tenantId: string;
+  type?: string;
+  token: string;
+}
+
+interface ICreateTaxonomyParams {
+  tenantId: string;
+  type: string;
+  value: string;
+  sortOrder?: number;
+  token: string;
+}
+
+interface IUpdateTaxonomyParams {
+  id: string;
+  tenantId: string;
+  value?: string;
+  sortOrder?: number;
+  token: string;
+}
+
+interface IDeleteTaxonomyParams {
+  id: string;
+  tenantId: string;
+  token: string;
+}
+
+/******************************************************************************
+                            TaxonomyService
+******************************************************************************/
+
+class TaxonomyService {
+  async getTaxonomies(params: IGetTaxonomiesParams): Promise<ITaxonomy[]> {
+    try {
+      const filters = {
+        tenant_id: params.tenantId,
+        ...(params.type ? { type: params.type } : {}),
+      };
+
+      const taxonomies = await taxonomyRepository.findByTenant(
+        params.token,
+        filters,
+      );
+
+      return taxonomies.sort(
+        (a, b) =>
+          a.sort_order - b.sort_order || a.value.localeCompare(b.value),
+      );
+    } catch (error) {
+      return handleServiceError('TaxonomyService.getTaxonomies', error);
+    }
+  }
+
+  async createTaxonomy(params: ICreateTaxonomyParams): Promise<ITaxonomy> {
+    try {
+      loggingService.info('TaxonomyService.createTaxonomy called', {
+        tenantId: params.tenantId,
+        type: params.type,
+        value: params.value,
+      });
+
+      return await taxonomyRepository.insert(params.token, {
+        tenant_id: params.tenantId,
+        type: params.type,
+        value: params.value,
+        sort_order: params.sortOrder ?? 0,
+      });
+    } catch (error) {
+      const rootCause = getRootCause(error);
+      if (
+        rootCause instanceof TaxonomyConflictError ||
+        rootCause instanceof TaxonomyNotFoundError
+      ) {
+        throw rootCause;
+      }
+      return handleServiceError('TaxonomyService.createTaxonomy', error);
+    }
+  }
+
+  async updateTaxonomy(params: IUpdateTaxonomyParams): Promise<ITaxonomy> {
+    try {
+      loggingService.info('TaxonomyService.updateTaxonomy called', {
+        id: params.id,
+        tenantId: params.tenantId,
+      });
+
+      const values: TaxonomiesUpdate = {};
+      if (params.value !== undefined) values.value = params.value;
+      if (params.sortOrder !== undefined) values.sort_order = params.sortOrder;
+
+      return await taxonomyRepository.update(
+        params.token,
+        { id: params.id, tenant_id: params.tenantId },
+        values,
+      );
+    } catch (error) {
+      const rootCause = getRootCause(error);
+      if (
+        rootCause instanceof TaxonomyConflictError ||
+        rootCause instanceof TaxonomyNotFoundError
+      ) {
+        throw rootCause;
+      }
+      return handleServiceError('TaxonomyService.updateTaxonomy', error);
+    }
+  }
+
+  async deleteTaxonomy(params: IDeleteTaxonomyParams): Promise<void> {
+    try {
+      loggingService.info('TaxonomyService.deleteTaxonomy called', {
+        id: params.id,
+        tenantId: params.tenantId,
+      });
+
+      await taxonomyRepository.remove(params.token, {
+        id: params.id,
+        tenant_id: params.tenantId,
+      });
+    } catch (error) {
+      const rootCause = getRootCause(error);
+      if (
+        rootCause instanceof TaxonomyConflictError ||
+        rootCause instanceof TaxonomyNotFoundError
+      ) {
+        throw rootCause;
+      }
+      return handleServiceError('TaxonomyService.deleteTaxonomy', error);
+    }
+  }
+}
+
+/******************************************************************************
+                                Export
+******************************************************************************/
+
+export const taxonomyService = new TaxonomyService();
+export default taxonomyService;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -884,6 +884,44 @@ export type Database = {
           },
         ]
       }
+      taxonomies: {
+        Row: {
+          created_at: string
+          id: string
+          sort_order: number
+          tenant_id: string
+          type: string
+          updated_at: string
+          value: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          sort_order?: number
+          tenant_id: string
+          type: string
+          updated_at?: string
+          value: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          sort_order?: number
+          tenant_id?: string
+          type?: string
+          updated_at?: string
+          value?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "taxonomies_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       tenants: {
         Row: {
           created_at: string

--- a/src/types/taxonomy.types.ts
+++ b/src/types/taxonomy.types.ts
@@ -1,0 +1,8 @@
+import { Database } from '@src/types/database.types';
+
+type TaxonomiesRow = Database['public']['Tables']['taxonomies']['Row'];
+
+export type ITaxonomy = Pick<
+  TaxonomiesRow,
+  'id' | 'tenant_id' | 'type' | 'value' | 'sort_order' | 'created_at' | 'updated_at'
+>;

--- a/supabase/migrations/20260626115137_create_taxonomies_table.sql
+++ b/supabase/migrations/20260626115137_create_taxonomies_table.sql
@@ -1,0 +1,64 @@
+-- Generic, tenant-configurable lookup table backing dropdown values.
+-- A single table holds every kind of configurable list, distinguished by `type`
+-- (e.g. 'product', 'prospect_source', 'rejection_reason'). A new dropdown is a new
+-- `type` value — no schema change required.
+
+-- Shared updated_at trigger function (idempotent; safe to re-declare).
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE taxonomies (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- tenant_id scopes every entry to one tenant; cascade removes entries when a tenant is deleted.
+  tenant_id  UUID        NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  -- type is the category of dropdown, e.g. 'product', 'prospect_source', 'rejection_reason'.
+  type       TEXT        NOT NULL,
+  -- value is the display string shown in the dropdown, e.g. 'Life Insurance'.
+  value      TEXT        NOT NULL,
+  -- sort_order controls dropdown ordering; lower appears first.
+  sort_order INT         NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- prevents duplicate values within the same type for the same tenant; different tenants
+  -- or different types may reuse the same value.
+  UNIQUE (tenant_id, type, value)
+);
+
+-- optimises the primary access pattern: fetch all values of one type for one tenant.
+CREATE INDEX idx_taxonomies_tenant_type ON taxonomies (tenant_id, type);
+
+CREATE TRIGGER trg_taxonomies_updated_at
+  BEFORE UPDATE ON taxonomies
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+ALTER TABLE taxonomies ENABLE ROW LEVEL SECURITY;
+
+-- Reads are open to every authenticated role within the owning tenant.
+CREATE POLICY "taxonomies_read" ON taxonomies
+FOR SELECT USING (
+  tenant_id = (auth.jwt() ->> 'tenant_id')::UUID
+);
+
+-- Mutations are admin-only and confined to the actor's own tenant.
+CREATE POLICY "taxonomies_insert" ON taxonomies
+FOR INSERT WITH CHECK (
+  tenant_id = (auth.jwt() ->> 'tenant_id')::UUID
+  AND (auth.jwt() ->> 'app_role') IN ('admin')
+);
+
+CREATE POLICY "taxonomies_update" ON taxonomies
+FOR UPDATE USING (
+  tenant_id = (auth.jwt() ->> 'tenant_id')::UUID
+  AND (auth.jwt() ->> 'app_role') IN ('admin')
+);
+
+CREATE POLICY "taxonomies_delete" ON taxonomies
+FOR DELETE USING (
+  tenant_id = (auth.jwt() ->> 'tenant_id')::UUID
+  AND (auth.jwt() ->> 'app_role') IN ('admin')
+);

--- a/tests/integration/taxonomies.test.ts
+++ b/tests/integration/taxonomies.test.ts
@@ -1,0 +1,481 @@
+import path from 'path';
+import request from 'supertest';
+
+import app from '@src/app';
+import { supabaseService } from '@src/services/supabase.service';
+
+/******************************************************************************
+  Integration — Taxonomies CRUD
+    GET    /api/taxonomies        (all roles)
+    POST   /api/taxonomies        (admin only)
+    PUT    /api/taxonomies/:id     (admin only)
+    DELETE /api/taxonomies/:id     (admin only)
+
+  NOTE: Cross-tenant isolation is enforced by RLS plus the service-layer tenant
+  filter, but it is NOT exercised here: the seed fixtures define a single tenant
+  (per project decision), so there is no second tenant to assert against.
+******************************************************************************/
+
+// Credentials are sourced from the seed manifest written by scripts/bootstrap.js.
+const manifest = require(path.join(
+  __dirname,
+  '../../scripts/seed-manifest.json',
+)) as {
+  tenantSlug: string;
+  adminPassword: string;
+  password: string;
+  users: Record<string, { id: string; email: string; role: string }>;
+};
+
+const TENANT_SLUG = manifest.tenantSlug;
+
+const ADMIN_EMAIL = manifest.users.admin.email;
+const ADMIN_PASSWORD = manifest.adminPassword;
+
+const AGENT_EMAIL = manifest.users.mdrt_stars_agent.email;
+const AGENT_PASSWORD = manifest.password;
+
+const NON_EXISTENT_ID = '00000000-0000-0000-0000-000000000000';
+
+// Unique types per run so this suite is independent and self-cleaning.
+const RUN = Date.now();
+const TYPE = `test_product_${RUN}`;
+const TYPE_ORDER = `test_order_${RUN}`;
+const TYPE_EMPTY = `test_empty_${RUN}`;
+
+let adminToken: string | null = null;
+let agentToken: string | null = null;
+
+/** Track every taxonomy id created by the test so afterAll can clean them up. */
+const createdIds: (string | null)[] = [];
+
+function track(id: string): string {
+  createdIds.push(id);
+  return id;
+}
+
+function adminAuth() {
+  return `Bearer ${adminToken}`;
+}
+
+function agentAuth() {
+  return `Bearer ${agentToken}`;
+}
+
+/******************************************************************************
+  beforeAll — obtain tokens via real login
+******************************************************************************/
+
+beforeAll(async () => {
+  const adminRes = await request(app)
+    .post('/api/auth/login')
+    .set('X-Tenant-Slug', TENANT_SLUG)
+    .send({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+
+  if (adminRes.status === 200 && adminRes.body?.data?.token) {
+    adminToken = adminRes.body.data.token as string;
+  }
+
+  const agentRes = await request(app)
+    .post('/api/auth/login')
+    .set('X-Tenant-Slug', TENANT_SLUG)
+    .send({ email: AGENT_EMAIL, password: AGENT_PASSWORD });
+
+  if (agentRes.status === 200 && agentRes.body?.data?.token) {
+    agentToken = agentRes.body.data.token as string;
+  }
+}, 30000);
+
+/******************************************************************************
+  afterAll — delete every taxonomy created by the test (best-effort)
+******************************************************************************/
+
+afterAll(async () => {
+  for (const id of createdIds) {
+    if (!id) continue;
+    try {
+      await supabaseService.adminDelete('taxonomies', { id });
+    } catch {
+      // best-effort
+    }
+  }
+});
+
+/******************************************************************************
+  POST /api/taxonomies — happy path
+******************************************************************************/
+
+describe('POST /api/taxonomies — happy path', () => {
+  it('returns 201 with the created taxonomy when admin creates a value', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const res = await request(app)
+      .post('/api/taxonomies')
+      .set('Authorization', adminAuth())
+      .send({ type: TYPE, value: 'Whole Life', sort_order: 3 });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('success', true);
+    expect(res.body).toHaveProperty('data');
+
+    const data = res.body.data as Record<string, unknown>;
+    expect(data).toHaveProperty('id');
+    expect(data).toHaveProperty('tenant_id');
+    expect(data).toHaveProperty('type', TYPE);
+    expect(data).toHaveProperty('value', 'Whole Life');
+    expect(data).toHaveProperty('sort_order', 3);
+    expect(data).toHaveProperty('created_at');
+    expect(data).toHaveProperty('updated_at');
+
+    track(data['id'] as string);
+  });
+});
+
+/******************************************************************************
+  GET /api/taxonomies — ordering, access, optional filter, validation
+******************************************************************************/
+
+describe('GET /api/taxonomies — ordering', () => {
+  it('returns values ordered by sort_order asc then value asc', async () => {
+    expect(adminToken).not.toBeNull();
+
+    // Insert deliberately out of order: Banana[2], Apple[1], Cherry[1].
+    const rows = [
+      { value: 'Banana', sort_order: 2 },
+      { value: 'Apple', sort_order: 1 },
+      { value: 'Cherry', sort_order: 1 },
+    ];
+
+    for (const row of rows) {
+      const res = await request(app)
+        .post('/api/taxonomies')
+        .set('Authorization', adminAuth())
+        .send({ type: TYPE_ORDER, ...row });
+      expect(res.status).toBe(201);
+      track(res.body.data.id as string);
+    }
+
+    const getRes = await request(app)
+      .get(`/api/taxonomies?type=${TYPE_ORDER}`)
+      .set('Authorization', adminAuth());
+
+    expect(getRes.status).toBe(200);
+    expect(getRes.body.success).toBe(true);
+    expect(Array.isArray(getRes.body.data)).toBe(true);
+
+    const values = (getRes.body.data as { value: string }[]).map((r) => r.value);
+    // sort_order asc then value asc → Apple[1], Cherry[1], Banana[2]
+    expect(values).toEqual(['Apple', 'Cherry', 'Banana']);
+  });
+});
+
+describe('GET /api/taxonomies — access', () => {
+  it('is accessible to a non-admin role (agent) → 200 with an array', async () => {
+    expect(agentToken).not.toBeNull();
+
+    const res = await request(app)
+      .get(`/api/taxonomies?type=${TYPE_ORDER}`)
+      .set('Authorization', agentAuth());
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+});
+
+describe('GET /api/taxonomies — optional type filter', () => {
+  it('returns an array (>= created rows) when no type filter is supplied', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const res = await request(app)
+      .get('/api/taxonomies')
+      .set('Authorization', adminAuth());
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    // At minimum the four rows created so far (1 base + 3 ordering) are present.
+    expect(res.body.data.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('returns an empty array for a type that has no rows', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const res = await request(app)
+      .get(`/api/taxonomies?type=${TYPE_EMPTY}`)
+      .set('Authorization', adminAuth());
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data).toHaveLength(0);
+  });
+});
+
+describe('GET /api/taxonomies — query validation', () => {
+  it('returns 400 when type is an empty string', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const res = await request(app)
+      .get('/api/taxonomies?type=')
+      .set('Authorization', adminAuth());
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('message', 'Validation failed');
+  });
+});
+
+describe('GET /api/taxonomies — auth guard', () => {
+  it('returns 401 when no Authorization header is provided', async () => {
+    const res = await request(app).get('/api/taxonomies');
+    expect(res.status).toBe(401);
+  });
+});
+
+/******************************************************************************
+  POST /api/taxonomies — duplicate / validation / guards
+******************************************************************************/
+
+describe('POST /api/taxonomies — duplicate', () => {
+  it('returns 409 when the same (type, value) is created twice', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const value = `Dup-${RUN}`;
+
+    const first = await request(app)
+      .post('/api/taxonomies')
+      .set('Authorization', adminAuth())
+      .send({ type: TYPE, value });
+
+    expect(first.status).toBe(201);
+    track(first.body.data.id as string);
+
+    const second = await request(app)
+      .post('/api/taxonomies')
+      .set('Authorization', adminAuth())
+      .send({ type: TYPE, value });
+
+    expect(second.status).toBe(409);
+  });
+});
+
+describe('POST /api/taxonomies — body validation', () => {
+  it('returns 400 when value is missing', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const res = await request(app)
+      .post('/api/taxonomies')
+      .set('Authorization', adminAuth())
+      .send({ type: TYPE });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('message', 'Validation failed');
+  });
+
+  it('returns 400 when value is an empty string', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const res = await request(app)
+      .post('/api/taxonomies')
+      .set('Authorization', adminAuth())
+      .send({ type: TYPE, value: '' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('message', 'Validation failed');
+  });
+
+  it('returns 400 when the body contains an unknown key (strict schema)', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const res = await request(app)
+      .post('/api/taxonomies')
+      .set('Authorization', adminAuth())
+      .send({ type: TYPE, value: 'Term Life', extra: 'nope' });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('message', 'Validation failed');
+  });
+});
+
+describe('POST /api/taxonomies — guards', () => {
+  it('returns 403 for a non-admin role (agent) with a valid body', async () => {
+    expect(agentToken).not.toBeNull();
+
+    const res = await request(app)
+      .post('/api/taxonomies')
+      .set('Authorization', agentAuth())
+      .send({ type: TYPE, value: `Agent-${RUN}` });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 when no Authorization header is provided', async () => {
+    const res = await request(app)
+      .post('/api/taxonomies')
+      .send({ type: TYPE, value: `NoAuth-${RUN}` });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+/******************************************************************************
+  PUT /api/taxonomies/:id — happy path / validation / guards / not found
+******************************************************************************/
+
+describe('PUT /api/taxonomies/:id — happy path', () => {
+  it('returns 200 and reflects the updated value and sort_order', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const createRes = await request(app)
+      .post('/api/taxonomies')
+      .set('Authorization', adminAuth())
+      .send({ type: TYPE, value: `ToUpdate-${RUN}`, sort_order: 5 });
+
+    expect(createRes.status).toBe(201);
+    const id = track(createRes.body.data.id as string);
+
+    const newValue = `Updated-${RUN}`;
+    const res = await request(app)
+      .put(`/api/taxonomies/${id}`)
+      .set('Authorization', adminAuth())
+      .send({ value: newValue, sort_order: 9 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const data = res.body.data as Record<string, unknown>;
+    expect(data).toHaveProperty('id', id);
+    expect(data).toHaveProperty('value', newValue);
+    expect(data).toHaveProperty('sort_order', 9);
+    expect(data).toHaveProperty('type', TYPE);
+  });
+});
+
+describe('PUT /api/taxonomies/:id — body validation', () => {
+  it('returns 400 for an empty body (no value or sort_order)', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const res = await request(app)
+      .put(`/api/taxonomies/${NON_EXISTENT_ID}`)
+      .set('Authorization', adminAuth())
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('message', 'Validation failed');
+  });
+});
+
+describe('PUT /api/taxonomies/:id — guards', () => {
+  it('returns 403 for a non-admin role (agent) with a valid body', async () => {
+    expect(agentToken).not.toBeNull();
+
+    const createRes = await request(app)
+      .post('/api/taxonomies')
+      .set('Authorization', adminAuth())
+      .send({ type: TYPE, value: `PutGuard-${RUN}` });
+    expect(createRes.status).toBe(201);
+    const id = track(createRes.body.data.id as string);
+
+    const res = await request(app)
+      .put(`/api/taxonomies/${id}`)
+      .set('Authorization', agentAuth())
+      .send({ value: 'X' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 when no Authorization header is provided', async () => {
+    const res = await request(app)
+      .put(`/api/taxonomies/${NON_EXISTENT_ID}`)
+      .send({ value: 'X' });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PUT /api/taxonomies/:id — not found', () => {
+  it('returns 404 for a non-existent id within the tenant', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const res = await request(app)
+      .put(`/api/taxonomies/${NON_EXISTENT_ID}`)
+      .set('Authorization', adminAuth())
+      .send({ value: `Ghost-${RUN}` });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+/******************************************************************************
+  DELETE /api/taxonomies/:id — happy path / guards / not found
+******************************************************************************/
+
+describe('DELETE /api/taxonomies/:id — guards', () => {
+  it('returns 403 for a non-admin role (agent)', async () => {
+    expect(agentToken).not.toBeNull();
+
+    const createRes = await request(app)
+      .post('/api/taxonomies')
+      .set('Authorization', adminAuth())
+      .send({ type: TYPE, value: `DeleteGuard-${RUN}` });
+    expect(createRes.status).toBe(201);
+    const id = track(createRes.body.data.id as string);
+
+    const res = await request(app)
+      .delete(`/api/taxonomies/${id}`)
+      .set('Authorization', agentAuth());
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 401 when no Authorization header is provided', async () => {
+    const res = await request(app).delete(`/api/taxonomies/${NON_EXISTENT_ID}`);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('DELETE /api/taxonomies/:id — not found', () => {
+  it('returns 404 for a non-existent id within the tenant', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const res = await request(app)
+      .delete(`/api/taxonomies/${NON_EXISTENT_ID}`)
+      .set('Authorization', adminAuth());
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/taxonomies/:id — happy path', () => {
+  it('returns 204 and the row is gone afterwards', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const createRes = await request(app)
+      .post('/api/taxonomies')
+      .set('Authorization', adminAuth())
+      .send({ type: TYPE, value: `Throwaway-${RUN}` });
+    expect(createRes.status).toBe(201);
+
+    const id = createRes.body.data.id as string;
+    const trackIndex = createdIds.push(id) - 1;
+
+    const delRes = await request(app)
+      .delete(`/api/taxonomies/${id}`)
+      .set('Authorization', adminAuth());
+
+    expect(delRes.status).toBe(204);
+    expect(delRes.body).toEqual({});
+
+    // Null out the tracking entry so afterAll does not double-delete.
+    createdIds[trackIndex] = null;
+
+    // Confirm it is gone via a filtered GET.
+    const getRes = await request(app)
+      .get(`/api/taxonomies?type=${TYPE}`)
+      .set('Authorization', adminAuth());
+
+    expect(getRes.status).toBe(200);
+    const found = (getRes.body.data as { id: string }[]).find(
+      (r) => r.id === id,
+    );
+    expect(found).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a generic, tenant-configurable **taxonomy** system — a single lookup table backing every kind of admin-managed dropdown (products today; prospect sources, rejection reasons, etc. tomorrow), distinguished by a `type` column. A new dropdown is just a new `type` value — **zero schema changes**. Nothing is hardcoded or seeded; each tenant's admin manages their own values.

## Endpoints (`/api/taxonomies`)

| Method | Path | Access | Notes |
|---|---|---|---|
| `GET` | `/api/taxonomies?type=<type>` | all roles (tenant-scoped) | optional `type` filter; ordered by `sort_order` then `value` |
| `POST` | `/api/taxonomies` | **admin** | **409** on duplicate `(tenant_id, type, value)` |
| `PUT` | `/api/taxonomies/:id` | **admin** | **404** if not in tenant; **409** on value collision |
| `DELETE` | `/api/taxonomies/:id` | **admin** | **204**; **404** if not in tenant |

## What's included

- **Migration** — `taxonomies` table with `UNIQUE(tenant_id, type, value)`, `(tenant_id, type)` index, FK to `tenants` `ON DELETE CASCADE`, the shared `set_updated_at()` trigger, and RLS policies (tenant-scoped reads for all roles; admin-only insert/update/delete). Generated types regenerated to match.
- **API module** — controller / service / repository / routes / domain errors, following the layered architecture and mirroring the existing `pointConfig` (admin-gated lookup CRUD) and `agentCode` (Postgres `23505` → clean 409, and 404) patterns. Tenant scoping is enforced in the service layer in addition to RLS (defence in depth).
- **Tests** — `tests/integration/taxonomies.test.ts`, **22 passing**: create, list + `type` filter + ordering, non-admin read access, 409 duplicate, 400 validation (body & query), 403 admin enforcement, 401 unauthenticated, 404 not-found, and PUT/DELETE happy paths.
- **OpenAPI** — `/taxonomies` & `/taxonomies/{id}` paths, `TaxonomyObject` schema, `Taxonomies` tag.

## Notes

- Tenant-isolation coverage stays on the existing single-tenant fixtures (cross-tenant is enforced by RLS + the service-layer tenant filter, but not exercised by a dedicated test — would require adding a second tenant to shared fixtures).
- A frontend integration guide was authored at `docs/TAXONOMIES_FE_INTEGRATION.md`; `docs/` is gitignored, so it ships as a local handoff artifact rather than in this PR.

## Verification

- `tsc -b --noEmit` → clean; new files lint clean.
- `npx jest tests/integration/taxonomies.test.ts` → 22/22 passing against the local Supabase stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)