### PR TITLE
feat(labels): add tenant label resolution API

### DIFF
--- a/.claude/skills/commit-organiser/SKILL.md
+++ b/.claude/skills/commit-organiser/SKILL.md
@@ -13,3 +13,4 @@ You are an experienced developer specialising in creating clean, well-structured
 ## Constraints
 * Do not modify any code. Your job is purely to organise and commit existing changes.
 * If you are unsure whether two changes belong in the same commit, err on the side of separating them.
+* Ignore the files in /docs folder, as they are not relevant to the commit organisation process and already in the .gitgitignore file.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34,6 +34,8 @@ tags:
     description: Tenant-scoped agent code provisioning endpoints
   - name: Taxonomies
     description: Tenant-configurable lookup values for dropdowns, grouped by type
+  - name: Labels
+    description: Tenant-scoped i18n-style display label resolution for stable internal keys
   - name: Coaching Sessions
     description: Coaching session management and attendance endpoints
   - name: Sales Reports
@@ -4175,6 +4177,72 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 message: Taxonomy not found
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  ##############################################################################
+  # LABELS
+  ##############################################################################
+
+  /labels:
+    get:
+      tags: [Labels]
+      summary: Get tenant labels
+      description: >
+        Returns the resolved key→value display-label map for the authenticated
+        tenant. Labels provide i18n-style resolution where the tenant acts as the
+        locale: code references stable internal keys (e.g. `metric.ace`) and this
+        endpoint resolves them to per-tenant display strings. The tenant is
+        derived from the JWT — clients cannot specify it. All authenticated roles
+        may read.
+
+
+        The response is a single merged map: a default label set provides
+        fallbacks, and the tenant's own overrides (from the `tenant_labels` table)
+        take precedence over the defaults.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Tenant labels retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, data]
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    description: >
+                      Map of stable internal label keys to their resolved
+                      per-tenant display strings.
+                    additionalProperties:
+                      type: string
+              example:
+                success: true
+                data:
+                  metric.ace: ACE
+                  metric.fyc: FYC
+                  metric.fyct: FYCt
+                  metric.acs: ACS (ACE/NOC)
+                  action.create_coaching: Create Peer Circle Meeting
+        '401':
+          description: >
+            Unauthorized. Returned when the `Authorization` header is absent,
+            malformed, or contains an invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                message: Unauthorized
         '500':
           description: Internal server error
           content:

--- a/src/constants/defaultLabels.ts
+++ b/src/constants/defaultLabels.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_LABELS: Record<string, string> = {
+  'metric.ace': 'Value',
+  'metric.acs': 'ACS (Value/NOC)',
+  'metric.fyct': 'Actual Collection',
+  'metric.fyc': 'Comm.',
+  'metric.total_ace': 'Total Value',
+  'action.create_coaching': 'Create Event',
+};

--- a/src/controllers/tenantLabel.controller.ts
+++ b/src/controllers/tenantLabel.controller.ts
@@ -1,0 +1,52 @@
+import { NextFunction, Response } from 'express';
+
+import { IBaseReq, IBaseRes } from '@src/models/interfaces/base.interface';
+import tenantLabelService from '@src/services/tenantLabel.service';
+import { handleControllerError } from '@src/utils/errorHandlers';
+import HttpStatusCodes from '@src/utils/HttpStatusCodes';
+
+/******************************************************************************
+                            Interfaces
+******************************************************************************/
+
+export interface IGetLabelsRes extends IBaseRes {
+  success: boolean;
+  data: Record<string, string>;
+}
+
+/******************************************************************************
+                            TenantLabelController
+******************************************************************************/
+
+class TenantLabelController {
+  async getAll(
+    req: IBaseReq,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const token = req.headers['authorization']!.slice(7);
+
+      const data = await tenantLabelService.getLabels({
+        tenantId: req.user!.tenant_id,
+        token,
+      });
+
+      const responseBody: IGetLabelsRes = {
+        success: true,
+        data,
+      };
+
+      res.status(HttpStatusCodes.OK).json(responseBody);
+    } catch (error) {
+      return handleControllerError('TenantLabelController.getAll', error, next);
+    }
+  }
+}
+
+/******************************************************************************
+                                Export
+******************************************************************************/
+
+export const tenantLabelController = new TenantLabelController();
+export default tenantLabelController;

--- a/src/repositories/tenantLabel.repository.ts
+++ b/src/repositories/tenantLabel.repository.ts
@@ -1,0 +1,53 @@
+import supabaseService from '@src/services/supabase.service';
+import { Database } from '@src/types/database.types';
+import { ITenantLabel } from '@src/types/tenantLabel.types';
+import { handleRepositoryError } from '@src/utils/errorHandlers';
+
+type TenantLabelsRow = Database['public']['Tables']['tenant_labels']['Row'];
+
+/******************************************************************************
+                            TenantLabelRepository
+******************************************************************************/
+
+class TenantLabelRepository {
+  private mapRowToTenantLabel(row: TenantLabelsRow): ITenantLabel {
+    return {
+      id: row.id,
+      tenant_id: row.tenant_id,
+      key: row.key,
+      value: row.value,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+    };
+  }
+
+  async findByTenant(
+    userToken: string,
+    filters: { tenant_id: string },
+  ): Promise<ITenantLabel[]> {
+    try {
+      const response = await supabaseService.userSelect(
+        userToken,
+        'tenant_labels',
+        '*',
+        filters,
+      );
+
+      if (response.error) {
+        throw new Error(response.error.message);
+      }
+
+      const rows = (response.data ?? []) as unknown as TenantLabelsRow[];
+      return rows.map((row) => this.mapRowToTenantLabel(row));
+    } catch (error) {
+      return handleRepositoryError('TenantLabelRepository.findByTenant', error);
+    }
+  }
+}
+
+/******************************************************************************
+                                Export
+******************************************************************************/
+
+export const tenantLabelRepository = new TenantLabelRepository();
+export default tenantLabelRepository;

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -17,6 +17,7 @@ import reportJobRoutes from '@src/routes/reportJob.routes';
 import salesReportRoutes from '@src/routes/salesReport.routes';
 import salesReportReadRoutes from '@src/routes/salesReportRead.routes';
 import taxonomyRoutes from '@src/routes/taxonomy.routes';
+import tenantLabelRoutes from '@src/routes/tenantLabel.routes';
 import userRoutes from '@src/routes/user.routes';
 
 const router = express.Router();
@@ -38,6 +39,7 @@ router.use('/dashboard', dashboardRoutes);
 router.use('/point-activity-types', pointActivityTypeRoutes);
 router.use('/point-configs', pointConfigRoutes);
 router.use('/taxonomies', taxonomyRoutes);
+router.use('/labels', tenantLabelRoutes);
 router.use('/leaderboard', leaderboardRoutes);
 router.use('/agent-points', agentPointsRoutes);
 router.use('/agent-codes', agentCodeRoutes);

--- a/src/routes/tenantLabel.routes.ts
+++ b/src/routes/tenantLabel.routes.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+
+import tenantLabelController from '@src/controllers/tenantLabel.controller';
+import { authenticate } from '@src/middleware/auth';
+import { IBaseReq } from '@src/models/interfaces/base.interface';
+
+/******************************************************************************
+                            Router
+******************************************************************************/
+
+const router = express.Router();
+
+router.get(
+  '/',
+  authenticate,
+  (req, res, next) =>
+    tenantLabelController.getAll(req as unknown as IBaseReq, res, next),
+);
+
+export default router;

--- a/src/services/tenantLabel.service.ts
+++ b/src/services/tenantLabel.service.ts
@@ -1,0 +1,42 @@
+import { DEFAULT_LABELS } from '@src/constants/defaultLabels';
+import tenantLabelRepository from '@src/repositories/tenantLabel.repository';
+import { handleServiceError } from '@src/utils/errorHandlers';
+
+/******************************************************************************
+                            Interfaces
+******************************************************************************/
+
+interface IGetLabelsParams {
+  tenantId: string;
+  token: string;
+}
+
+/******************************************************************************
+                            TenantLabelService
+******************************************************************************/
+
+class TenantLabelService {
+  async getLabels(params: IGetLabelsParams): Promise<Record<string, string>> {
+    try {
+      const rows = await tenantLabelRepository.findByTenant(params.token, {
+        tenant_id: params.tenantId,
+      });
+
+      const merged: Record<string, string> = { ...DEFAULT_LABELS };
+      for (const row of rows) {
+        merged[row.key] = row.value;
+      }
+
+      return merged;
+    } catch (error) {
+      return handleServiceError('TenantLabelService.getLabels', error);
+    }
+  }
+}
+
+/******************************************************************************
+                                Export
+******************************************************************************/
+
+export const tenantLabelService = new TenantLabelService();
+export default tenantLabelService;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -922,6 +922,41 @@ export type Database = {
           },
         ]
       }
+      tenant_labels: {
+        Row: {
+          created_at: string
+          id: string
+          key: string
+          tenant_id: string
+          updated_at: string
+          value: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          key: string
+          tenant_id: string
+          updated_at?: string
+          value: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          key?: string
+          tenant_id?: string
+          updated_at?: string
+          value?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tenant_labels_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       tenants: {
         Row: {
           created_at: string

--- a/src/types/tenantLabel.types.ts
+++ b/src/types/tenantLabel.types.ts
@@ -1,0 +1,8 @@
+import { Database } from '@src/types/database.types';
+
+type TenantLabelsRow = Database['public']['Tables']['tenant_labels']['Row'];
+
+export type ITenantLabel = Pick<
+  TenantLabelsRow,
+  'id' | 'tenant_id' | 'key' | 'value' | 'created_at' | 'updated_at'
+>;

--- a/supabase/migrations/20260626133410_create_tenant_labels_table.sql
+++ b/supabase/migrations/20260626133410_create_tenant_labels_table.sql
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TABLE tenant_labels (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id  UUID        NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  key        TEXT        NOT NULL,
+  value      TEXT        NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, key)
+);
+
+CREATE INDEX idx_tenant_labels_tenant ON tenant_labels (tenant_id);
+
+CREATE TRIGGER trg_tenant_labels_updated_at
+  BEFORE UPDATE ON tenant_labels
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+ALTER TABLE tenant_labels ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "tenant_labels_read" ON tenant_labels
+FOR SELECT USING (
+  tenant_id = (auth.jwt() ->> 'tenant_id')::UUID
+);
+-- No insert/update/delete policies. Labels are seeded by developers via the
+-- service role (RLS-bypassing). RLS denies all other authenticated writes by default.

--- a/tests/integration/labels.test.ts
+++ b/tests/integration/labels.test.ts
@@ -1,0 +1,218 @@
+import path from 'path';
+import request from 'supertest';
+
+import app from '@src/app';
+import { DEFAULT_LABELS } from '@src/constants/defaultLabels';
+import { supabaseService } from '@src/services/supabase.service';
+
+/******************************************************************************
+  Integration — Tenant Labels (read-only)
+    GET /api/labels   (all roles) — merged DEFAULT_LABELS + tenant overrides
+
+  NOTE: Cross-tenant isolation is enforced by RLS plus the service-layer tenant
+  filter, but it is NOT exercised here: the seed fixtures define a single tenant
+  (per project decision), so there is no second tenant to assert against. This
+  mirrors the taxonomies integration suite.
+******************************************************************************/
+
+// Credentials are sourced from the seed manifest written by scripts/bootstrap.js.
+const manifest = require(path.join(
+  __dirname,
+  '../../scripts/seed-manifest.json',
+)) as {
+  tenantId: string;
+  tenantSlug: string;
+  adminPassword: string;
+  password: string;
+  users: Record<string, { id: string; email: string; role: string }>;
+};
+
+const TENANT_ID = manifest.tenantId;
+const TENANT_SLUG = manifest.tenantSlug;
+
+const ADMIN_EMAIL = manifest.users.admin.email;
+const ADMIN_PASSWORD = manifest.adminPassword;
+
+const AGENT_EMAIL = manifest.users.mdrt_stars_agent.email;
+const AGENT_PASSWORD = manifest.password;
+
+// A default key the test guarantees it never overrides — used to assert the
+// default value survives even when other keys are overridden by the tenant.
+const NON_OVERRIDDEN_KEY = 'metric.fyct';
+const NON_OVERRIDDEN_DEFAULT = DEFAULT_LABELS[NON_OVERRIDDEN_KEY];
+
+// The key the override test replaces for the seeded tenant.
+const OVERRIDE_KEY = 'metric.ace';
+const OVERRIDE_VALUE = 'ACE';
+
+let adminToken: string | null = null;
+let agentToken: string | null = null;
+
+/** Track every tenant_labels id created by the test so afterAll can clean up. */
+const createdIds: (string | null)[] = [];
+
+function track(id: string): string {
+  createdIds.push(id);
+  return id;
+}
+
+function adminAuth() {
+  return `Bearer ${adminToken}`;
+}
+
+function agentAuth() {
+  return `Bearer ${agentToken}`;
+}
+
+/******************************************************************************
+  beforeAll — obtain tokens via real login
+******************************************************************************/
+
+beforeAll(async () => {
+  const adminRes = await request(app)
+    .post('/api/auth/login')
+    .set('X-Tenant-Slug', TENANT_SLUG)
+    .send({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD });
+
+  if (adminRes.status === 200 && adminRes.body?.data?.token) {
+    adminToken = adminRes.body.data.token as string;
+  }
+
+  const agentRes = await request(app)
+    .post('/api/auth/login')
+    .set('X-Tenant-Slug', TENANT_SLUG)
+    .send({ email: AGENT_EMAIL, password: AGENT_PASSWORD });
+
+  if (agentRes.status === 200 && agentRes.body?.data?.token) {
+    agentToken = agentRes.body.data.token as string;
+  }
+}, 30000);
+
+/******************************************************************************
+  afterAll — delete every tenant_labels row created by the test (best-effort)
+******************************************************************************/
+
+afterAll(async () => {
+  for (const id of createdIds) {
+    if (!id) continue;
+    try {
+      await supabaseService.adminDelete('tenant_labels', { id });
+    } catch {
+      // best-effort
+    }
+  }
+});
+
+/******************************************************************************
+  GET /api/labels — defaults when no overrides
+******************************************************************************/
+
+describe('GET /api/labels — defaults when no overrides', () => {
+  it('returns the default value for a key the tenant has not overridden', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const res = await request(app)
+      .get('/api/labels')
+      .set('Authorization', adminAuth());
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('success', true);
+    expect(res.body).toHaveProperty('data');
+
+    const data = res.body.data as Record<string, string>;
+    expect(data[NON_OVERRIDDEN_KEY]).toBe(NON_OVERRIDDEN_DEFAULT);
+  });
+});
+
+/******************************************************************************
+  GET /api/labels — all default keys present
+******************************************************************************/
+
+describe('GET /api/labels — all default keys present', () => {
+  it('includes every key from DEFAULT_LABELS in the response map', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const res = await request(app)
+      .get('/api/labels')
+      .set('Authorization', adminAuth());
+
+    expect(res.status).toBe(200);
+    const data = res.body.data as Record<string, string>;
+
+    // NOTE: Label keys contain dots (e.g. 'metric.ace'). Jest's toHaveProperty
+    // treats a dotted string as a nested keypath, so assert membership via the
+    // own-keys list and bracket access instead.
+    const responseKeys = Object.keys(data);
+    for (const key of Object.keys(DEFAULT_LABELS)) {
+      expect(responseKeys).toContain(key);
+      expect(typeof data[key]).toBe('string');
+    }
+  });
+});
+
+/******************************************************************************
+  GET /api/labels — tenant override replaces default
+******************************************************************************/
+
+describe('GET /api/labels — tenant override replaces default', () => {
+  it('returns the tenant override while non-overridden keys keep defaults', async () => {
+    expect(adminToken).not.toBeNull();
+
+    const insertRes = await supabaseService.adminInsert('tenant_labels', {
+      tenant_id: TENANT_ID,
+      key: OVERRIDE_KEY,
+      value: OVERRIDE_VALUE,
+    });
+
+    expect(insertRes.error).toBeNull();
+    const inserted = (insertRes.data ?? []) as { id: string }[];
+    expect(inserted.length).toBeGreaterThan(0);
+    track(inserted[0].id);
+
+    const res = await request(app)
+      .get('/api/labels')
+      .set('Authorization', adminAuth());
+
+    expect(res.status).toBe(200);
+    const data = res.body.data as Record<string, string>;
+
+    // Override wins for the overridden key.
+    expect(data[OVERRIDE_KEY]).toBe(OVERRIDE_VALUE);
+    // A non-overridden key still shows its default value.
+    expect(data[NON_OVERRIDDEN_KEY]).toBe(NON_OVERRIDDEN_DEFAULT);
+  });
+});
+
+/******************************************************************************
+  GET /api/labels — agent role can read
+******************************************************************************/
+
+describe('GET /api/labels — access', () => {
+  it('is accessible to a non-admin role (agent) → 200 with a populated map', async () => {
+    expect(agentToken).not.toBeNull();
+
+    const res = await request(app)
+      .get('/api/labels')
+      .set('Authorization', agentAuth());
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const data = res.body.data as Record<string, string>;
+    expect(Object.keys(data).length).toBeGreaterThanOrEqual(
+      Object.keys(DEFAULT_LABELS).length,
+    );
+    expect(data[NON_OVERRIDDEN_KEY]).toBe(NON_OVERRIDDEN_DEFAULT);
+  });
+});
+
+/******************************************************************************
+  GET /api/labels — auth guard
+******************************************************************************/
+
+describe('GET /api/labels — auth guard', () => {
+  it('returns 401 when no Authorization header is provided', async () => {
+    const res = await request(app).get('/api/labels');
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a tenant-specific label layer — i18n-style label resolution where the **tenant acts as the locale**. Code references stable internal keys (e.g. `metric.ace`); the label layer resolves them to per-tenant display strings (Zurich sees `"ACE"`, other tenants see the generic `"Value"`). A default label set provides fallbacks for any key a tenant hasn't overridden.

Labels are developer-managed (seeded via the service role, which bypasses RLS) — admins cannot edit them. The app needs only a read endpoint.

### Endpoint

`GET /api/labels` — all authenticated roles. Returns a single merged `key → value` map: start from `DEFAULT_LABELS`, overlay the tenant's `tenant_labels` rows (tenant overrides win).

```json
{ "success": true, "data": { "metric.ace": "ACE", "metric.fyc": "FYC", "action.create_coaching": "Create Peer Circle Meeting" } }
```

## What's included

- **Migration** — `tenant_labels` table (`UNIQUE(tenant_id, key)`, FK cascade on tenant delete, `set_updated_at()` trigger) with a tenant-scoped RLS **read** policy. No write policies — RLS denies authenticated writes by default; developers seed via the service role.
- **API** — `defaultLabels` constant, derived `ITenantLabel` type, plus repository / service / controller / route following the existing Controller → Service → Repository layering. Merge logic lives in the service; tenant scoping is applied in the service layer as defence in depth alongside RLS. Mirrors the recently-merged taxonomies module.
- **Tests** — integration coverage: defaults when no overrides, all default keys present, tenant override replaces default, non-admin read access, and the unauthenticated 401 guard. **5/5 passing.**
- **Docs** — `GET /labels` documented in `openapi.yaml` under a new `Labels` tag.

## Notes

- Uses the codebase's real `set_updated_at()` trigger (the original brief referenced `update_updated_at_column()`, which does not exist in this repo).
- Response uses the house `{ success, data }` envelope for consistency with the rest of the API.
- Branch also contains one unrelated commit (`5af8b59`) tweaking the commit-organiser skill doc.

## Verification

- `npm run lint` and typecheck: clean.
- `npx jest tests/integration/labels.test.ts`: 5/5 pass (requires local Supabase seeded via `npm run bootstrap`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)